### PR TITLE
Fix ui bugs and extract icon button component

### DIFF
--- a/src/app/browse/molecules/page.tsx
+++ b/src/app/browse/molecules/page.tsx
@@ -13,6 +13,7 @@ import { BrowseTabs } from "~/app/components/BrowseTabs";
 import { Squares2X2Icon, ListBulletIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { AddMoleculeButton } from "~/app/components/AddEntityButtons";
+import { IconToggleButton } from "~/app/components/IconToggleButton";
 
 function MoleculesBrowseContent() {
   const searchParams = useSearchParams();
@@ -251,28 +252,18 @@ function MoleculesBrowseContent() {
           <div className="flex items-center gap-4">
             {/* View Toggle */}
             <div className="flex items-center gap-1 rounded-lg border border-gray-300 bg-white p-1 dark:border-gray-600 dark:bg-gray-800">
-              <button
+              <IconToggleButton
+                icon={<ListBulletIcon className="h-4 w-4" />}
+                isActive={viewMode === "compact"}
                 onClick={() => setViewMode("compact")}
-                className={`rounded px-3 py-1.5 text-sm transition-colors ${
-                  viewMode === "compact"
-                    ? "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
-                    : "text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
-                }`}
-                aria-label="Compact view"
-              >
-                <ListBulletIcon className="h-4 w-4" />
-              </button>
-              <button
+                ariaLabel="Compact view"
+              />
+              <IconToggleButton
+                icon={<Squares2X2Icon className="h-4 w-4" />}
+                isActive={viewMode === "spacious"}
                 onClick={() => setViewMode("spacious")}
-                className={`rounded px-3 py-1.5 text-sm transition-colors ${
-                  viewMode === "spacious"
-                    ? "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
-                    : "text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
-                }`}
-                aria-label="Spacious view"
-              >
-                <Squares2X2Icon className="h-4 w-4" />
-              </button>
+                ariaLabel="Spacious view"
+              />
             </div>
 
             {!hasSearchQuery && (

--- a/src/app/components/IconToggleButton.tsx
+++ b/src/app/components/IconToggleButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+interface IconToggleButtonProps {
+  icon: ReactNode;
+  isActive: boolean;
+  onClick: () => void;
+  ariaLabel: string;
+  className?: string;
+}
+
+/**
+ * IconToggleButton - A reusable toggle button component for icon-only buttons
+ * Matches the styling pattern used in the browse molecules view toggle
+ */
+export function IconToggleButton({
+  icon,
+  isActive,
+  onClick,
+  ariaLabel,
+  className = "",
+}: IconToggleButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded px-3 py-1.5 text-sm transition-colors ${
+        isActive
+          ? "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+          : "text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+      } ${className}`}
+      aria-label={ariaLabel}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/src/app/components/contribute/nexafs/SubToolButton.tsx
+++ b/src/app/components/contribute/nexafs/SubToolButton.tsx
@@ -27,7 +27,7 @@ export function SubToolButton({
   const baseClasses =
     "flex h-10 items-center justify-center gap-1.5 rounded-lg border transition-colors disabled:cursor-not-allowed disabled:opacity-50";
   const activeClasses =
-    "border-wsu-crimson bg-wsu-crimson text-white shadow-sm dark:border-wsu-crimson dark:bg-wsu-crimson dark:text-white";
+    "border-gray-300 bg-gray-100 text-gray-600 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300";
   const inactiveClasses =
     "border-gray-300 bg-white hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600";
   const sizeClasses = iconOnly ? "w-10" : "flex-1";


### PR DESCRIPTION
Extract `IconToggleButton` component and update `SubToolButton` styling to resolve UI/UX bug where selected sub-tools in light mode appeared completely white.

The active state of sub-tools in light mode now displays a gray shaded background, consistent with the browse compact mode toggle, providing better visual feedback for selected tools.

---
<a href="https://cursor.com/background-agent?bcId=bc-32d1fe3f-fcc0-438a-b96a-232755408525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32d1fe3f-fcc0-438a-b96a-232755408525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

