### PR TITLE
fix: update button event handler in ErrorState component

### DIFF
--- a/src/app/components/ErrorState.tsx
+++ b/src/app/components/ErrorState.tsx
@@ -29,7 +29,7 @@ export function ErrorState({
         </p>
       </div>
       {onRetry && (
-        <Button onClick={onRetry} variant="outline">
+        <Button onPress={onRetry} variant="outline">
           {retryLabel}
         </Button>
       )}

--- a/src/components/feedback/error-state.tsx
+++ b/src/components/feedback/error-state.tsx
@@ -29,7 +29,7 @@ export function ErrorState({
         </p>
       </div>
       {onRetry && (
-        <Button onClick={onRetry} variant="outline">
+        <Button onPress={onRetry} variant="outline">
           {retryLabel}
         </Button>
       )}


### PR DESCRIPTION
## Summary

Follow-up fix after the colocation migration PR #33.

- Fixed button event handler type in ErrorState component

## Test Plan
- [x] TypeScript compilation passes
- [x] Production build passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps the retry button handler prop from `onClick` to `onPress` to match the underlying HeroUI `Button` API, affecting only error/empty-state interactions.
> 
> **Overview**
> Updates both `ErrorState` implementations (`src/app/components/ErrorState.tsx` and `src/components/feedback/error-state.tsx`) to wire the retry action via `Button`’s `onPress` prop instead of `onClick`, aligning with the HeroUI-backed `DefaultButton` wrapper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35daa55620148f9d3b551e92d4a2b7679c175e84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->