### PR TITLE
Fix first-login ORCID persistence and default NEXAFS OD view

### DIFF
--- a/src/features/process-nexafs/hooks/useNexafsSpectrumBrowseModel.ts
+++ b/src/features/process-nexafs/hooks/useNexafsSpectrumBrowseModel.ts
@@ -40,8 +40,7 @@ export interface UseNexafsSpectrumBrowseModelResult {
 export function useNexafsSpectrumBrowseModel({
   spectrumPoints,
 }: UseNexafsSpectrumBrowseModelArgs): UseNexafsSpectrumBrowseModelResult {
-  const [dataView, setDataViewState] =
-    useState<NexafsBrowseDataView>("absorption");
+  const [dataView, setDataViewState] = useState<NexafsBrowseDataView>("od");
   const gateToastRef = useRef<Record<string, number>>({});
 
   const showGateToast = useCallback((key: string, message: string) => {

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -12,6 +12,7 @@ import {
   type UserSessionCapabilities,
 } from "~/server/auth/privileged-role";
 import { DEV_MOCK_USER_ID } from "~/lib/dev-mock-data";
+import { parseOrcidForStorage } from "~/lib/orcid";
 
 const emptySessionCapabilities: UserSessionCapabilities = {
   canAccessLabs: false,
@@ -28,6 +29,17 @@ interface ORCIDProfile {
   given_name?: string;
   family_name?: string;
   email?: string;
+}
+
+function getPersistableOrcid(provider: string, providerAccountId: string): string | null {
+  if (provider !== "orcid") {
+    return null;
+  }
+  try {
+    return parseOrcidForStorage(providerAccountId);
+  } catch {
+    return null;
+  }
 }
 
 function ORCID(
@@ -191,12 +203,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
                 data: { userId: currentUserId },
               });
 
-              if (account.provider === "orcid" && account.providerAccountId) {
-                let orcidId = account.providerAccountId;
-                if (orcidId.startsWith("https://orcid.org/")) {
-                  orcidId = orcidId.replace("https://orcid.org/", "");
-                }
-                orcidId = orcidId.replace(/\/$/, "");
+              const orcidId = getPersistableOrcid(
+                account.provider,
+                account.providerAccountId,
+              );
+              if (orcidId) {
                 await db.user.update({
                   where: { id: currentUserId },
                   data: { orcid: orcidId },
@@ -212,12 +223,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
               data: { userId: currentUserId },
             });
 
-            if (account.provider === "orcid" && account.providerAccountId) {
-              let orcidId = account.providerAccountId;
-              if (orcidId.startsWith("https://orcid.org/")) {
-                orcidId = orcidId.replace("https://orcid.org/", "");
-              }
-              orcidId = orcidId.replace(/\/$/, "");
+            const orcidId = getPersistableOrcid(
+              account.provider,
+              account.providerAccountId,
+            );
+            if (orcidId) {
               await db.user.update({
                 where: { id: currentUserId },
                 data: { orcid: orcidId },
@@ -278,13 +288,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           account.providerAccountId &&
           user.id
         ) {
-          let orcidId = account.providerAccountId;
-
-          if (orcidId.startsWith("https://orcid.org/")) {
-            orcidId = orcidId.replace("https://orcid.org/", "");
+          const orcidId = getPersistableOrcid(
+            account.provider,
+            account.providerAccountId,
+          );
+          if (!orcidId) {
+            cookieStore.delete("linkAccountUserId");
+            cookieStore.delete("linkAccountProvider");
+            return true;
           }
-
-          orcidId = orcidId.replace(/\/$/, "");
 
           try {
             const existingUser = await db.user.findUnique({
@@ -407,6 +419,32 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         };
       }
       return session;
+    },
+  },
+  events: {
+    async linkAccount({ user, account }) {
+      const orcidId = getPersistableOrcid(
+        account.provider,
+        account.providerAccountId,
+      );
+      if (!orcidId) {
+        return;
+      }
+
+      try {
+        await db.user.update({
+          where: { id: user.id },
+          data: { orcid: orcidId },
+        });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+        console.error("[NextAuth] Error persisting ORCID on linkAccount:", errorMessage, {
+          userId: user.id,
+          orcidId,
+          providerAccountId: account.providerAccountId,
+        });
+      }
     },
   },
   pages: {


### PR DESCRIPTION
## Summary
- persist ORCID IDs during auth account-link events so first-time ORCID sign-ins populate `user.orcid` immediately
- reuse shared ORCID parsing via `parseOrcidForStorage` for canonical persisted values in auth callbacks
- switch the default NEXAFS browse plot data view from `absorption` (mu/mass absorption) to `od`

## Test plan
- [x] Verified diff is limited to `src/server/auth.ts` and `src/features/process-nexafs/hooks/useNexafsSpectrumBrowseModel.ts`
- [x] `bunx eslint src/features/process-nexafs/hooks/useNexafsSpectrumBrowseModel.ts`
- [ ] `bun run typecheck` *(currently fails on existing repository-wide baseline errors unrelated to this PR)*

## AI Role
- Level 2: Extensive AI-assisted implementation with constrained scope, explicit validation, and human-directed objectives.