### PR TITLE
feat(plots): client-side inspect pins on spectrum plot

### DIFF
--- a/src/components/plots/hooks/useInspectPins.ts
+++ b/src/components/plots/hooks/useInspectPins.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import type { PinnedInspectPoint } from "../types";
+
+export type UseInspectPinsResult = {
+  pins: PinnedInspectPoint[];
+  selectedPinId: string | null;
+  addPin: (energy: number) => string;
+  removePin: (id: string) => void;
+  updatePinEnergy: (id: string, energy: number) => void;
+  selectPin: (id: string | null) => void;
+  clearPins: () => void;
+};
+
+function makePinId(seq: number, energy: number): string {
+  return `pin-${seq}-${energy.toFixed(3)}`;
+}
+
+/**
+ * Lightweight client-side state container for inspect pins on the spectrum
+ * plot. Pins are never persisted; this hook only exposes the imperative
+ * operations the plot needs to add, move, delete, and select pins, and keeps
+ * a stable list ordering so the popover "Pin N" labels stay consistent while
+ * any given pin exists.
+ *
+ * Returns
+ * -------
+ * pins : PinnedInspectPoint[]
+ *     Current pin list in insertion order.
+ * selectedPinId : string | null
+ *     The id of the most recently interacted pin (used for stacking order
+ *     of popovers and emphasized rail styling).
+ * addPin : (energy: number) => string
+ *     Appends a pin and returns its new id.
+ * removePin : (id: string) => void
+ *     Drops the pin with the given id and clears selection if it matched.
+ * updatePinEnergy : (id: string, energy: number) => void
+ *     Updates the axis position of an existing pin (fast path for drag).
+ * selectPin : (id: string | null) => void
+ *     Marks a pin as the active pin without mutating positions.
+ * clearPins : () => void
+ *     Removes all pins.
+ */
+export function useInspectPins(): UseInspectPinsResult {
+  const [pins, setPins] = useState<PinnedInspectPoint[]>([]);
+  const [selectedPinId, setSelectedPinId] = useState<string | null>(null);
+  const seqRef = useRef(0);
+
+  const addPin = useCallback((energy: number) => {
+    const next = ++seqRef.current;
+    const id = makePinId(next, energy);
+    setPins((prev) => [...prev, { id, energy }]);
+    setSelectedPinId(id);
+    return id;
+  }, []);
+
+  const removePin = useCallback((id: string) => {
+    setPins((prev) => prev.filter((p) => p.id !== id));
+    setSelectedPinId((prev) => (prev === id ? null : prev));
+  }, []);
+
+  const updatePinEnergy = useCallback((id: string, energy: number) => {
+    setPins((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, energy } : p)),
+    );
+  }, []);
+
+  const selectPin = useCallback((id: string | null) => {
+    setSelectedPinId(id);
+  }, []);
+
+  const clearPins = useCallback(() => {
+    setPins([]);
+    setSelectedPinId(null);
+  }, []);
+
+  return {
+    pins,
+    selectedPinId,
+    addPin,
+    removePin,
+    updatePinEnergy,
+    selectPin,
+    clearPins,
+  };
+}

--- a/src/components/plots/spectrum/DraggablePlotPopover.tsx
+++ b/src/components/plots/spectrum/DraggablePlotPopover.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { ChevronDown, ChevronRight, X } from "lucide-react";
+
+export type PopoverOffset = {
+  dx: number;
+  dy: number;
+};
+
+/**
+ * Free-floating HTML popover anchored at a base (x, y) in overlay CSS pixels
+ * and offset by a user-draggable `(dx, dy)`. The offset is controlled by the
+ * caller so the owning component can persist the popover position across pin
+ * selection or axis-drag events without the popover snapping back to the
+ * anchor.
+ *
+ * The component stops pointer-down propagation on its container so interactions
+ * inside the popover do not fall through to the plot's pan / zoom / click
+ * handlers. The header provides the drag grip; all other areas are
+ * interactive.
+ *
+ * Parameters
+ * ----------
+ * anchorXCss, anchorYCss : number
+ *     Position in overlay CSS space where the popover "wants" to be before
+ *     the user starts dragging.
+ * offset : PopoverOffset
+ *     Current delta from the anchor. Controlled by the parent so dragging is
+ *     a pure state update and the axis anchor can move independently.
+ * onOffsetChange : (next: PopoverOffset) => void
+ *     Called during drag with the new offset.
+ * onFocus : (() => void) | undefined
+ *     Called on pointer-down anywhere in the popover to raise z-index (e.g.
+ *     select the underlying pin).
+ * onClose : () => void
+ *     Closes the popover.
+ * title : ReactNode
+ *     Rendered in the header next to the drag grip.
+ * zIndex : number
+ *     CSS z-index; typically elevated for the selected popover.
+ * children : ReactNode
+ *     Popover body.
+ * collapsed : boolean
+ *     When true, only the header row is shown; body is hidden.
+ * onCollapsedChange : (collapsed: boolean) => void
+ *     Toggles collapse from the chevron control in the header.
+ */
+export function DraggablePlotPopover({
+  anchorXCss,
+  anchorYCss,
+  offset,
+  onOffsetChange,
+  onFocus,
+  onClose,
+  title,
+  zIndex,
+  children,
+  collapsed,
+  onCollapsedChange,
+}: {
+  anchorXCss: number;
+  anchorYCss: number;
+  offset: PopoverOffset;
+  onOffsetChange: (next: PopoverOffset) => void;
+  onFocus?: () => void;
+  onClose: () => void;
+  title: ReactNode;
+  zIndex: number;
+  children: ReactNode;
+  collapsed: boolean;
+  onCollapsedChange: (collapsed: boolean) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState<{ w: number; h: number }>({ w: 200, h: 100 });
+  const dragStartRef = useRef<{
+    clientX: number;
+    clientY: number;
+    dx: number;
+    dy: number;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    const el = containerRef.current;
+    const measure = () => {
+      setSize({ w: el.offsetWidth, h: el.offsetHeight });
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const handleHeaderPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onFocus?.();
+      dragStartRef.current = {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        dx: offset.dx,
+        dy: offset.dy,
+      };
+      (event.currentTarget as HTMLDivElement).setPointerCapture?.(
+        event.pointerId,
+      );
+    },
+    [offset.dx, offset.dy, onFocus],
+  );
+
+  const handleHeaderPointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const start = dragStartRef.current;
+      if (!start) return;
+      event.preventDefault();
+      const nextDx = start.dx + (event.clientX - start.clientX);
+      const nextDy = start.dy + (event.clientY - start.clientY);
+      onOffsetChange({ dx: nextDx, dy: nextDy });
+    },
+    [onOffsetChange],
+  );
+
+  const handleHeaderPointerUp = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!dragStartRef.current) return;
+      (event.currentTarget as HTMLDivElement).releasePointerCapture?.(
+        event.pointerId,
+      );
+      dragStartRef.current = null;
+    },
+    [],
+  );
+
+  const stopPropagation = useCallback((event: React.SyntheticEvent) => {
+    event.stopPropagation();
+  }, []);
+
+  const leftPx = anchorXCss + offset.dx - size.w / 2;
+  const topPx = anchorYCss + offset.dy;
+
+  return (
+    <div
+      ref={containerRef}
+      className="pointer-events-auto absolute select-none rounded-md border border-[color-mix(in_oklab,var(--chart-grid-strong)_55%,transparent)] bg-[color-mix(in_oklab,var(--chart-paper)_98%,transparent)] text-[var(--chart-text)] shadow-lg"
+      style={{
+        left: leftPx,
+        top: topPx,
+        zIndex,
+        minWidth: collapsed ? 160 : 208,
+      }}
+      onPointerDown={(event) => {
+        onFocus?.();
+        event.stopPropagation();
+      }}
+      onWheel={stopPropagation}
+      onContextMenu={stopPropagation}
+    >
+      <div
+        className={
+          collapsed
+            ? "flex cursor-grab items-center gap-1.5 rounded-md bg-[color-mix(in_oklab,var(--chart-background)_80%,transparent)] px-2 py-1 active:cursor-grabbing"
+            : "flex cursor-grab items-center gap-1.5 rounded-t-md border-b border-[color-mix(in_oklab,var(--chart-grid-strong)_55%,transparent)] bg-[color-mix(in_oklab,var(--chart-background)_80%,transparent)] px-2 py-1 active:cursor-grabbing"
+        }
+        onPointerDown={handleHeaderPointerDown}
+        onPointerMove={handleHeaderPointerMove}
+        onPointerUp={handleHeaderPointerUp}
+        onPointerCancel={handleHeaderPointerUp}
+        style={{ touchAction: "none" }}
+      >
+        <span
+          className="flex h-3 w-3 shrink-0 flex-col justify-between"
+          aria-hidden
+        >
+          <span className="h-0.5 w-full rounded bg-[var(--chart-text-secondary)] opacity-60" />
+          <span className="h-0.5 w-full rounded bg-[var(--chart-text-secondary)] opacity-60" />
+          <span className="h-0.5 w-full rounded bg-[var(--chart-text-secondary)] opacity-60" />
+        </span>
+        <div className="min-w-0 flex-1 truncate text-[11px] font-semibold tracking-tight">
+          {title}
+        </div>
+        <button
+          type="button"
+          className="rounded p-0.5 text-[var(--chart-text-secondary)] transition-colors hover:bg-[color-mix(in_oklab,var(--chart-grid-strong)_25%,transparent)] hover:text-[var(--chart-text)]"
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? "Expand pin details" : "Collapse pin details"}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onCollapsedChange(!collapsed);
+          }}
+        >
+          {collapsed ? (
+            <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+          )}
+        </button>
+        <button
+          type="button"
+          className="rounded p-0.5 text-[var(--chart-text-secondary)] transition-colors hover:bg-[color-mix(in_oklab,var(--chart-grid-strong)_25%,transparent)] hover:text-[var(--chart-text)]"
+          aria-label="Close pinned inspect point"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+        >
+          <X className="h-3 w-3" aria-hidden />
+        </button>
+      </div>
+      {!collapsed ? (
+        <div className="px-2 py-1.5 text-[11px] leading-tight">{children}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/plots/spectrum/InspectPinLayer.tsx
+++ b/src/components/plots/spectrum/InspectPinLayer.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type RefObject,
+} from "react";
+import { Copy } from "lucide-react";
+import type { PinnedInspectPoint, PlotDimensions, TraceData } from "../types";
+import type { ChartScales } from "./types";
+import type { ChartThemeColors } from "../config";
+import { PEAK_SELECTION_ACCENT } from "../constants";
+import { PinnedAxisMarker } from "./PinnedAxisMarker";
+import {
+  DraggablePlotPopover,
+  type PopoverOffset,
+} from "./DraggablePlotPopover";
+import { getTraceColor, getTraceLabel, getValueAtEnergy } from "./utils";
+
+export type InspectPinLayerSlot = "svg" | "overlay";
+
+type PopoverOffsetMap = Record<string, PopoverOffset>;
+
+type InspectPinRow = {
+  label: string;
+  color: string;
+  value: number | null;
+};
+
+function defaultOffsetForIndex(index: number): PopoverOffset {
+  const stagger = 14 * index;
+  return { dx: 0, dy: 12 + stagger };
+}
+
+function formatEnergyEv(energy: number): string {
+  return (Math.round(energy * 1000) / 1000).toFixed(3);
+}
+
+function formatTraceValue(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return "\u2014";
+  const abs = Math.abs(value);
+  if (abs >= 1000 || (abs > 0 && abs < 0.001)) return value.toExponential(3);
+  return value.toPrecision(4);
+}
+
+function copyToClipboard(text: string): void {
+  if (typeof navigator === "undefined") return;
+  if (navigator.clipboard?.writeText) {
+    void navigator.clipboard.writeText(text);
+  }
+}
+
+function buildPinCsv(
+  energy: number,
+  rows: InspectPinRow[],
+): string {
+  const headers = ["energy_eV", ...rows.map((r) => r.label)];
+  const values = [
+    formatEnergyEv(energy),
+    ...rows.map((r) =>
+      r.value == null || !Number.isFinite(r.value) ? "" : String(r.value),
+    ),
+  ];
+  return `${headers.join(",")}\n${values.join(",")}`;
+}
+
+/**
+ * Renders inspect-pin visuals in either the SVG plot group or the HTML overlay
+ * layer. A single component owns both sides so popover offsets, hover focus,
+ * and pin ordering remain consistent between the two render passes.
+ *
+ * Parameters
+ * ----------
+ * slot : "svg" | "overlay"
+ *     Selects which subtree to render in the current pass. SVG pass draws
+ *     crosshairs + colored dots + the draggable rail marker; overlay pass
+ *     draws the HTML popovers.
+ * pins : PinnedInspectPoint[]
+ *     List of active client-side pins.
+ * selectedPinId : string | null
+ *     Id of the focused pin used to elevate z-index and emphasize the rail.
+ * visibleTraces : TraceData[]
+ *     Spectra currently shown on the plot. Rows and crosshair dots are
+ *     derived from these at render time so pins stay consistent with legend
+ *     toggles and y-axis quantity switches.
+ * scales : ChartScales
+ *     Main plot scales used by both SVG and overlay positioning.
+ * dimensions : PlotDimensions
+ *     Main plot dimensions used by both SVG and overlay positioning.
+ * themeColors : ChartThemeColors
+ *     Provides crosshair / text defaults.
+ * plotSvgRef : RefObject<SVGSVGElement | null>
+ *     Used by the rail marker to translate pointer `clientX` to energy.
+ * onSelectPin : (id: string | null) => void
+ *     Invoked when a pin's marker or popover is pressed.
+ * onRemovePin : (id: string) => void
+ *     Invoked by the popover close button.
+ * onUpdatePinEnergy : (id: string, energy: number) => void
+ *     Invoked while the user drags a pin's rail marker.
+ * overlayWidth, overlayHeight : number
+ *     Dimensions of the HTML overlay; used for absolute positioning only.
+ */
+export function InspectPinLayer({
+  slot,
+  pins,
+  selectedPinId,
+  visibleTraces,
+  scales,
+  dimensions,
+  themeColors,
+  plotSvgRef,
+  onSelectPin,
+  onRemovePin,
+  onUpdatePinEnergy,
+  overlayWidth,
+  overlayHeight,
+}: {
+  slot: InspectPinLayerSlot;
+  pins: PinnedInspectPoint[];
+  selectedPinId: string | null;
+  visibleTraces: TraceData[];
+  scales: ChartScales;
+  dimensions: PlotDimensions;
+  themeColors: ChartThemeColors;
+  plotSvgRef: RefObject<SVGSVGElement | null>;
+  onSelectPin: (id: string | null) => void;
+  onRemovePin: (id: string) => void;
+  onUpdatePinEnergy: (id: string, energy: number) => void;
+  overlayWidth: number;
+  overlayHeight: number;
+}) {
+  const [popoverOffsets, setPopoverOffsets] = useState<PopoverOffsetMap>({});
+  const [draggingPinId, setDraggingPinId] = useState<string | null>(null);
+  const [pinCollapsed, setPinCollapsed] = useState<Record<string, boolean>>({});
+
+  const setOffsetForPin = useCallback(
+    (pinId: string, next: PopoverOffset) => {
+      setPopoverOffsets((prev) => ({ ...prev, [pinId]: next }));
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (
+      draggingPinId != null &&
+      !pins.some((p) => p.id === draggingPinId)
+    ) {
+      setDraggingPinId(null);
+    }
+  }, [pins, draggingPinId]);
+
+  const pinRowsById = useMemo(() => {
+    const domain = scales.xScale.domain() as [number, number];
+    const range = Math.abs((domain[1] ?? 0) - (domain[0] ?? 0));
+    const threshold = Math.max(range * 0.02, 1e-9);
+    const map = new Map<string, InspectPinRow[]>();
+    for (const pin of pins) {
+      const rows: InspectPinRow[] = visibleTraces.map((trace, index) => ({
+        label: getTraceLabel(trace, index),
+        color: getTraceColor(trace, themeColors.text),
+        value: getValueAtEnergy(trace, pin.energy, threshold),
+      }));
+      map.set(pin.id, rows);
+    }
+    return map;
+  }, [pins, scales.xScale, themeColors.text, visibleTraces]);
+
+  if (pins.length === 0) return null;
+
+  if (slot === "svg") {
+    const plotHeight =
+      dimensions.height - dimensions.margins.top - dimensions.margins.bottom;
+    const crosshairColor = themeColors.crosshair ?? themeColors.text;
+
+    return (
+      <g data-inspect-pin-layer style={{ pointerEvents: "none" }}>
+        {pins.map((pin, index) => {
+          const gripActive = draggingPinId === pin.id;
+          const rows = pinRowsById.get(pin.id) ?? [];
+          const xLocal = scales.xScale(pin.energy);
+          return (
+            <g key={pin.id}>
+              <line
+                x1={xLocal}
+                y1={0}
+                x2={xLocal}
+                y2={plotHeight}
+                stroke={gripActive ? PEAK_SELECTION_ACCENT : crosshairColor}
+                strokeWidth={gripActive ? 1.5 : 1.25}
+                strokeDasharray={gripActive ? undefined : "5,4"}
+                opacity={gripActive ? 0.85 : 0.6}
+                pointerEvents="none"
+              />
+              {rows.map((row, rowIndex) =>
+                row.value == null ? null : (
+                  <circle
+                    key={`${pin.id}-dot-${rowIndex}`}
+                    cx={xLocal}
+                    cy={scales.yScale(row.value)}
+                    r={5}
+                    fill={row.color}
+                    stroke="rgba(255,255,255,0.9)"
+                    strokeWidth={1.5}
+                    opacity={0.95}
+                    pointerEvents="none"
+                  />
+                ),
+              )}
+              <PinnedAxisMarker
+                energy={pin.energy}
+                xScale={scales.xScale}
+                dimensions={dimensions}
+                plotSvgRef={plotSvgRef}
+                isSelected={gripActive}
+                fill={themeColors.legendBg}
+                selectedFill={PEAK_SELECTION_ACCENT}
+                outline={
+                  gripActive ? PEAK_SELECTION_ACCENT : themeColors.textSecondary
+                }
+                railColor={undefined}
+                labelTop={String(index + 1)}
+                onEnergyChange={(energy) => onUpdatePinEnergy(pin.id, energy)}
+                onPress={() => onSelectPin(pin.id)}
+                onGripPointerActiveChange={(active) =>
+                  setDraggingPinId(active ? pin.id : null)
+                }
+              />
+            </g>
+          );
+        })}
+      </g>
+    );
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute left-0 top-0 z-[18]"
+      style={{ width: overlayWidth, height: overlayHeight }}
+    >
+      {pins.map((pin, index) => {
+        const rows = pinRowsById.get(pin.id) ?? [];
+        const xCss = dimensions.margins.left + scales.xScale(pin.energy);
+        const yCss = dimensions.margins.top;
+        const offset = popoverOffsets[pin.id] ?? defaultOffsetForIndex(index);
+        const isSelected = selectedPinId === pin.id;
+        const collapsed = pinCollapsed[pin.id] === true;
+        return (
+          <DraggablePlotPopover
+            key={pin.id}
+            anchorXCss={xCss}
+            anchorYCss={yCss}
+            offset={offset}
+            onOffsetChange={(next) => setOffsetForPin(pin.id, next)}
+            onFocus={() => onSelectPin(pin.id)}
+            onClose={() => onRemovePin(pin.id)}
+            collapsed={collapsed}
+            onCollapsedChange={(next) =>
+              setPinCollapsed((prev) => ({ ...prev, [pin.id]: next }))
+            }
+            zIndex={isSelected ? 26 : 24}
+            title={
+              <span className="flex items-center gap-1.5">
+                <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-[color-mix(in_oklab,var(--chart-grid-strong)_45%,transparent)] bg-[color-mix(in_oklab,var(--chart-background)_88%,transparent)] px-1 text-[9px] font-semibold tabular-nums text-[var(--chart-text-secondary)]">
+                  {index + 1}
+                </span>
+                <span>Pin</span>
+                <span className="font-mono text-[11px] tabular-nums text-[var(--chart-text-secondary)]">
+                  {formatEnergyEv(pin.energy)} eV
+                </span>
+              </span>
+            }
+          >
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between gap-2 border-b border-[color-mix(in_oklab,var(--chart-grid-strong)_35%,transparent)] pb-1">
+                <div className="min-w-0 flex-1">
+                  <div className="text-[10px] uppercase tracking-wider text-[var(--chart-text-secondary)]">
+                    Energy
+                  </div>
+                  <div className="font-mono text-[12px] font-semibold tabular-nums">
+                    {formatEnergyEv(pin.energy)} eV
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <InlineCopyButton
+                    label="Copy energy"
+                    onCopy={() => copyToClipboard(formatEnergyEv(pin.energy))}
+                  />
+                  <button
+                    type="button"
+                    className="rounded border border-[color-mix(in_oklab,var(--chart-grid-strong)_45%,transparent)] bg-[color-mix(in_oklab,var(--chart-background)_82%,transparent)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--chart-text)] hover:bg-[color-mix(in_oklab,var(--chart-grid-strong)_25%,transparent)]"
+                    onClick={() =>
+                      copyToClipboard(buildPinCsv(pin.energy, rows))
+                    }
+                    title="Copy all values as CSV"
+                  >
+                    Copy all
+                  </button>
+                </div>
+              </div>
+              <ul className="flex flex-col gap-0.5 text-[11px]">
+                {rows.length === 0 ? (
+                  <li className="italic text-[var(--chart-text-secondary)]">
+                    No visible traces
+                  </li>
+                ) : (
+                  rows.map((row) => (
+                    <li
+                      key={row.label}
+                      className="flex items-center gap-1.5"
+                    >
+                      <span
+                        className="inline-block h-2 w-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: row.color }}
+                        aria-hidden
+                      />
+                      <span className="min-w-0 flex-1 truncate text-[var(--chart-text)]">
+                        {row.label}
+                      </span>
+                      <span className="font-mono tabular-nums text-[var(--chart-text)]">
+                        {formatTraceValue(row.value)}
+                      </span>
+                      <InlineCopyButton
+                        label={`Copy ${row.label}`}
+                        disabled={row.value == null}
+                        onCopy={() =>
+                          copyToClipboard(
+                            row.value == null ? "" : String(row.value),
+                          )
+                        }
+                      />
+                    </li>
+                  ))
+                )}
+              </ul>
+            </div>
+          </DraggablePlotPopover>
+        );
+      })}
+    </div>
+  );
+}
+
+function InlineCopyButton({
+  label,
+  onCopy,
+  disabled,
+}: {
+  label: string;
+  onCopy: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onClick={(event) => {
+        event.stopPropagation();
+        onCopy();
+      }}
+      className="rounded p-0.5 text-[var(--chart-text-secondary)] transition-colors hover:bg-[color-mix(in_oklab,var(--chart-grid-strong)_25%,transparent)] hover:text-[var(--chart-text)] disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      <Copy className="h-3 w-3" aria-hidden />
+    </button>
+  );
+}

--- a/src/components/plots/spectrum/PinnedAxisMarker.tsx
+++ b/src/components/plots/spectrum/PinnedAxisMarker.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import type { PlotDimensions } from "../types";
+import type { ChartScales } from "./types";
+
+/**
+ * Reusable SVG rail marker anchored to a fixed x-axis energy with an optional
+ * draggable grip. Pointer drags map `clientX` back to an `energy` value through
+ * the x-scale and are clamped to the plot drawing area. Exposes two handles —
+ * one at the top of the rail and one at the bottom when the plot is tall
+ * enough — so the marker remains reachable independently of where the data
+ * curve happens to pass the crosshair.
+ *
+ * The marker is the shared axis grip used by both persisted peaks and
+ * client-side inspect pins; peaks and pins configure it via props such as
+ * `fill`, `outline`, `label`, and `onEnergyChange`.
+ *
+ * Parameters
+ * ----------
+ * energy : number
+ *     Axis coordinate the marker snaps to.
+ * xScale : ScaleLinear<number, number>
+ *     Maps energy to local (left-margin-relative) pixel space.
+ * dimensions : PlotDimensions
+ *     Used to compute the rail height and the horizontal drag clamp.
+ * plotSvgRef : RefObject<SVGSVGElement | null>
+ *     Root plot SVG used to translate `PointerEvent.clientX` to plot space.
+ * isSelected : boolean
+ *     When true, the pill handles render in `selectedFill`/thicker stroke.
+ * onEnergyChange : ((energy: number) => void) | undefined
+ *     When defined, pointer-drag on a handle reports the new energy rounded
+ *     to 0.01 eV. When undefined, the marker is not draggable.
+ * onPress : (() => void) | undefined
+ *     Optional callback for click-without-drag on a handle (used to select
+ *     a pin when tapping its rail grip).
+ * fill : string
+ *     Base pill color when unselected.
+ * selectedFill : string
+ *     Pill color when `isSelected` is true.
+ * outline : string
+ *     Stroke color on both states.
+ * railColor : string | undefined
+ *     When set, draws a thin vertical rail line behind the pills in this
+ *     color; otherwise no rail line is drawn.
+ * labelTop : string | undefined
+ *     Optional tiny label rendered inside the top pill (e.g. "1" for pin
+ *     ordinal numbers). Truncated visually to one character.
+ * hitPadX : number
+ *     Half-width of the transparent pointer-hit rect around each handle.
+ * onGripPointerActiveChange : ((active: boolean) => void) | undefined
+ *     Fires true when the user presses a handle and false on release. Inspect
+ *     pins use this to show accent styling only while the grip is held; peaks
+ *     omit it and rely on `isSelected` alone.
+ */
+export function PinnedAxisMarker({
+  energy,
+  xScale,
+  dimensions,
+  plotSvgRef,
+  isSelected,
+  onEnergyChange,
+  onPress,
+  onGripPointerActiveChange,
+  fill,
+  selectedFill,
+  outline,
+  railColor,
+  labelTop,
+  hitPadX = 24,
+}: {
+  energy: number;
+  xScale: ChartScales["xScale"];
+  dimensions: PlotDimensions;
+  plotSvgRef: RefObject<SVGSVGElement | null>;
+  isSelected: boolean;
+  onEnergyChange?: (energy: number) => void;
+  onPress?: () => void;
+  onGripPointerActiveChange?: (active: boolean) => void;
+  fill: string;
+  selectedFill: string;
+  outline: string;
+  railColor?: string;
+  labelTop?: string;
+  hitPadX?: number;
+}) {
+  const xPos = xScale(energy);
+  const plotHeight =
+    dimensions.height - dimensions.margins.top - dimensions.margins.bottom;
+  const plotWidth =
+    dimensions.width - dimensions.margins.left - dimensions.margins.right;
+  const railInset = 11;
+  const topCenterY = railInset;
+  const bottomCenterY = Math.max(railInset, plotHeight - railInset);
+  const pillW = isSelected ? 24 : 20;
+  const pillH = 14;
+  const hitH = 32;
+  const dualHandles = bottomCenterY - topCenterY >= hitH - 2;
+
+  const [isDragging, setIsDragging] = useState(false);
+  const draggedRef = useRef(false);
+  const left = dimensions.margins.left;
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      if (!onEnergyChange) return;
+      const svg = plotSvgRef.current;
+      if (!svg) return;
+      const rect = svg.getBoundingClientRect();
+      const clientX = event.clientX - rect.left;
+      const adjustedX = clientX - left;
+      const clampedX = Math.max(0, Math.min(plotWidth, adjustedX));
+      const nextEnergy = xScale.invert(clampedX);
+      const rounded = Math.round(nextEnergy * 100) / 100;
+      if (Math.abs(rounded - energy) >= 0.005) {
+        draggedRef.current = true;
+      }
+      onEnergyChange(rounded);
+    },
+    [energy, left, onEnergyChange, plotSvgRef, plotWidth, xScale],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    setIsDragging(false);
+    onGripPointerActiveChange?.(false);
+    if (!draggedRef.current) onPress?.();
+    draggedRef.current = false;
+  }, [onPress, onGripPointerActiveChange]);
+
+  useEffect(() => {
+    if (!isDragging) return;
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+    };
+  }, [isDragging, handlePointerMove, handlePointerUp]);
+
+  const handlePointerDown = (e: React.PointerEvent<SVGRectElement>) => {
+    if (!onEnergyChange && !onPress) return;
+    e.preventDefault();
+    e.stopPropagation();
+    draggedRef.current = false;
+    onGripPointerActiveChange?.(true);
+    setIsDragging(true);
+  };
+
+  const stopPlotClick = (e: React.MouseEvent | React.PointerEvent) => {
+    e.stopPropagation();
+  };
+
+  const resolvedFill = isSelected ? selectedFill : fill;
+  const cursor = onEnergyChange
+    ? isDragging
+      ? "grabbing"
+      : "grab"
+    : onPress
+      ? "pointer"
+      : "default";
+
+  const handlePair = (centerY: number, key: string, showLabel: boolean) => {
+    const hitTop = centerY - hitH / 2;
+    const label = showLabel && labelTop ? labelTop.slice(0, 1) : null;
+    return (
+      <g key={key}>
+        <rect
+          x={xPos - hitPadX}
+          y={hitTop}
+          width={hitPadX * 2}
+          height={hitH}
+          fill="transparent"
+          cursor={cursor}
+          onPointerDown={handlePointerDown}
+          onClick={stopPlotClick}
+          style={{ touchAction: "none" }}
+        />
+        <rect
+          x={xPos - pillW / 2}
+          y={centerY - pillH / 2}
+          width={pillW}
+          height={pillH}
+          rx={pillH / 2}
+          fill={resolvedFill}
+          stroke={outline}
+          strokeWidth={isSelected ? 2 : 1.5}
+          opacity={isDragging ? 0.92 : 1}
+          pointerEvents="none"
+        />
+        {label ? (
+          <text
+            x={xPos}
+            y={centerY + 3}
+            textAnchor="middle"
+            fontSize={9}
+            fontWeight={600}
+            fill={outline}
+            pointerEvents="none"
+            style={{ userSelect: "none" }}
+          >
+            {label}
+          </text>
+        ) : null}
+      </g>
+    );
+  };
+
+  return (
+    <g style={{ pointerEvents: "all" }}>
+      {railColor ? (
+        <line
+          x1={xPos}
+          y1={topCenterY}
+          x2={xPos}
+          y2={bottomCenterY}
+          stroke={railColor}
+          strokeWidth={1}
+          strokeDasharray="3,3"
+          opacity={0.45}
+          pointerEvents="none"
+        />
+      ) : null}
+      {handlePair(topCenterY, "top", true)}
+      {dualHandles ? handlePair(bottomCenterY, "bottom", false) : null}
+    </g>
+  );
+}

--- a/src/components/plots/spectrum/SpectrumPlotInner.tsx
+++ b/src/components/plots/spectrum/SpectrumPlotInner.tsx
@@ -22,6 +22,7 @@ import { useReferenceData } from "../hooks/useReferenceData";
 import { useDataExtents } from "../hooks/useDataExtents";
 import { usePeakVisualization } from "../hooks/usePeakVisualization";
 import { findClosestPoint } from "../utils/find-closest-point";
+import { eventToPlotCoords } from "../utils/svgPlotPointer";
 import { PLOT_CONFIG, useChartThemeFromCSS } from "../config";
 import { useSubplotLayout } from "./useSubplotLayout";
 import { ChartAxes } from "./ChartAxes";
@@ -37,6 +38,8 @@ import {
   getTraceColor,
 } from "./utils";
 import { PeakPlotAnnotations } from "./PeakPlotAnnotations";
+import { InspectPinLayer } from "./InspectPinLayer";
+import { useInspectPins } from "../hooks/useInspectPins";
 import { NormalizationBrush } from "../visx/NormalizationBrush";
 import { PeakIndicators } from "../visx/PeakIndicators";
 import { PeakCurves } from "../visx/PeakCurves";
@@ -293,6 +296,15 @@ export function SpectrumPlotInner({
     [onCursorModeChange],
   );
 
+  const {
+    pins: inspectPins,
+    selectedPinId: selectedInspectPinId,
+    addPin: addInspectPin,
+    removePin: removeInspectPin,
+    updatePinEnergy: updateInspectPinEnergy,
+    selectPin: selectInspectPin,
+  } = useInspectPins();
+
   const tooltip = useTooltip<{
     energy: number;
     rows: Array<{ label: string; value: number | null; color: string }>;
@@ -404,6 +416,47 @@ export function SpectrumPlotInner({
     },
     [onPeakPatch, onPeakUpdate],
   );
+
+  const handlePlotAreaClick = useCallback(
+    (event: React.MouseEvent<SVGGElement>) => {
+      if (effectiveCursorMode !== "inspect") return;
+      if (isManualPeakMode) return;
+      if (selectionTarget != null) return;
+      const svg = svgRef.current;
+      if (!svg) return;
+      const pt = eventToPlotCoords(
+        event.nativeEvent,
+        svg,
+        mainPlot.dimensions.margins.left,
+        mainPlot.dimensions.margins.top,
+      );
+      if (!pt) return;
+      const localX = pt.x;
+      const plotInnerWidth =
+        mainPlot.dimensions.width -
+        mainPlot.dimensions.margins.left -
+        mainPlot.dimensions.margins.right;
+      if (localX < 0 || localX > plotInnerWidth) return;
+      const rawEnergy = zoomedXScale.invert(localX);
+      const rounded = Math.round(rawEnergy * 1000) / 1000;
+      addInspectPin(rounded);
+      tooltip.hideTooltip();
+    },
+    [
+      effectiveCursorMode,
+      isManualPeakMode,
+      selectionTarget,
+      mainPlot.dimensions,
+      zoomedXScale,
+      addInspectPin,
+      tooltip,
+    ],
+  );
+
+  const inspectPlotHitSurfaceActive =
+    effectiveCursorMode === "inspect" &&
+    !isManualPeakMode &&
+    selectionTarget == null;
 
   const energyRange = useMemo(() => {
     if (!peakViz.selectedGeometryPoints?.length) return [];
@@ -657,8 +710,17 @@ export function SpectrumPlotInner({
               onPointerMove={handlePanMove}
               onPointerUp={handlePanEnd}
               onPointerLeave={handlePanEnd}
+              onClick={handlePlotAreaClick}
             >
               <g clipPath={`url(#${plotClipId})`}>
+                <rect
+                  width={mainPlotWidth}
+                  height={mainPlotHeight}
+                  fill="transparent"
+                  style={{
+                    pointerEvents: inspectPlotHitSurfaceActive ? "all" : "none",
+                  }}
+                />
                 <ChartSpectrumLines
                   traces={visibleTraces}
                   scales={mainPlotScales}
@@ -689,6 +751,21 @@ export function SpectrumPlotInner({
                     getYValueAtEnergy={getYValueAtEnergy}
                   />
                 )}
+                <InspectPinLayer
+                  slot="svg"
+                  pins={inspectPins}
+                  selectedPinId={selectedInspectPinId}
+                  visibleTraces={visibleTraces}
+                  scales={mainPlotScales}
+                  dimensions={mainPlot.dimensions}
+                  themeColors={themeColors}
+                  plotSvgRef={svgRef}
+                  onSelectPin={selectInspectPin}
+                  onRemovePin={removeInspectPin}
+                  onUpdatePinEnergy={updateInspectPinEnergy}
+                  overlayWidth={width}
+                  overlayHeight={contentHeight}
+                />
               </g>
             </g>
             {selectionTarget && (
@@ -714,6 +791,7 @@ export function SpectrumPlotInner({
                 zoomMode={zoomMode}
                 onZoom={handleMarqueeZoom}
                 onReset={handleResetZoom}
+                allowPlotInteractionsBelow={zoomedXDomain != null}
               />
             )}
             {effectiveCursorMode === "pan" && zoomedXDomain != null && (
@@ -839,6 +917,21 @@ export function SpectrumPlotInner({
           onPeakPatch={onPeakPatch}
           onPeakUpdate={onPeakUpdate}
           visible={isManualPeakMode}
+          overlayWidth={width}
+          overlayHeight={contentHeight}
+        />
+        <InspectPinLayer
+          slot="overlay"
+          pins={inspectPins}
+          selectedPinId={selectedInspectPinId}
+          visibleTraces={visibleTraces}
+          scales={mainPlotScales}
+          dimensions={mainPlot.dimensions}
+          themeColors={themeColors}
+          plotSvgRef={svgRef}
+          onSelectPin={selectInspectPin}
+          onRemovePin={removeInspectPin}
+          onUpdatePinEnergy={updateInspectPinEnergy}
           overlayWidth={width}
           overlayHeight={contentHeight}
         />

--- a/src/components/plots/spectrum/index.ts
+++ b/src/components/plots/spectrum/index.ts
@@ -15,6 +15,11 @@ export { MultiTraceTooltip } from "./MultiTraceTooltip";
 export type { TraceTooltipRow } from "./MultiTraceTooltip";
 export { ChartCrosshairAndDots } from "./ChartCrosshairAndDots";
 export type { CrosshairDot } from "./ChartCrosshairAndDots";
+export { PinnedAxisMarker } from "./PinnedAxisMarker";
+export { DraggablePlotPopover } from "./DraggablePlotPopover";
+export type { PopoverOffset } from "./DraggablePlotPopover";
+export { InspectPinLayer } from "./InspectPinLayer";
+export type { InspectPinLayerSlot } from "./InspectPinLayer";
 export {
   getValueAtEnergy,
   getTraceLabel,

--- a/src/components/plots/types.ts
+++ b/src/components/plots/types.ts
@@ -63,6 +63,22 @@ export type PeakAnnotationPatch = {
   peakKind?: string | null;
 };
 
+/**
+ * Transient, client-only marker produced when a user clicks the plot while the
+ * inspect tool is active. Pinned points are intentionally not persisted; they
+ * exist only inside the plot component state to support ad-hoc comparison of
+ * energy values and per-trace intensities across the currently visible spectra.
+ *
+ * Only the stable `id` and axis `energy` are stored. Trace values shown in the
+ * associated popover are derived from the live visible traces each render so
+ * that normalization toggles, legend changes, and y-axis quantity switches stay
+ * reflected without having to refresh pins.
+ */
+export type PinnedInspectPoint = {
+  id: string;
+  energy: number;
+};
+
 export type DifferenceSpectrum = {
   label: string;
   points: SpectrumPoint[];

--- a/src/components/plots/utils/svgPlotPointer.ts
+++ b/src/components/plots/utils/svgPlotPointer.ts
@@ -1,5 +1,5 @@
 export function eventToPlotCoords(
-  event: PointerEvent,
+  event: Pick<MouseEvent, "clientX" | "clientY">,
   svg: SVGSVGElement,
   left: number,
   top: number,

--- a/src/components/plots/visx/BrushZoom.tsx
+++ b/src/components/plots/visx/BrushZoom.tsx
@@ -21,6 +21,13 @@ type BrushZoomProps = {
   zoomMode: ZoomMode;
   onZoom: (xDomain: [number, number], yDomain: [number, number]) => void;
   onReset?: () => void;
+  /**
+   * When true, the brush hit-target does not capture pointer events so clicks
+   * reach the plot below (inspect pins, tooltips, etc.). Use once a horizontal
+   * zoom is already applied; further zoom-in uses the toolbar buttons until
+   * the view is reset.
+   */
+  allowPlotInteractionsBelow?: boolean;
 };
 
 export function BrushZoom({
@@ -32,6 +39,7 @@ export function BrushZoom({
   zoomMode,
   onZoom,
   onReset,
+  allowPlotInteractionsBelow = false,
 }: BrushZoomProps) {
   const themeColors = themeColorsProp ?? (isDark ? THEME_COLORS.dark : THEME_COLORS.light);
 
@@ -151,8 +159,11 @@ export function BrushZoom({
         width={plotWidth}
         height={plotHeight}
         fill="transparent"
-        style={{ cursor: "crosshair" }}
-        onPointerDown={handlePointerDown}
+        style={{
+          cursor: allowPlotInteractionsBelow ? "default" : "crosshair",
+          pointerEvents: allowPlotInteractionsBelow ? "none" : "auto",
+        }}
+        onPointerDown={allowPlotInteractionsBelow ? undefined : handlePointerDown}
       />
       {marquee && (
         <rect

--- a/src/components/plots/visx/InteractivePeak.tsx
+++ b/src/components/plots/visx/InteractivePeak.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
 import { useTheme } from "next-themes";
 import type { Peak, PlotDimensions } from "../types";
 import type { VisxScales } from "../hooks/useVisxScales";
 import { PEAK_COLORS } from "../constants";
 import { peakStableId } from "../utils/peakStableId";
+import { PinnedAxisMarker } from "../spectrum/PinnedAxisMarker";
 
+/**
+ * Thin wrapper that renders a peak's draggable axis handles via the shared
+ * `PinnedAxisMarker`. Exists primarily to preserve the peak-specific
+ * `(peakId, energy)` update signature used by the visx peak interaction
+ * pipeline and to hide/show the marker based on the peak edit variant.
+ */
 export function InteractivePeak({
   peak,
   peakIndex,
@@ -31,118 +37,29 @@ export function InteractivePeak({
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
   const peakId = peakStableId(peak, peakIndex);
-  const energy = peak.energy;
-  const xPos = scales.xScale(energy);
-  const plotHeight =
-    dimensions.height - dimensions.margins.top - dimensions.margins.bottom;
-  const railInset = 11;
-  const topCenterY = railInset;
-  const bottomCenterY = Math.max(railInset, plotHeight - railInset);
-  const pillW = isSelected ? 24 : 20;
-  const pillH = 14;
-  const hitPadX = 26;
-  const hitH = 32;
-  const dualHandles = bottomCenterY - topCenterY >= hitH - 2;
-
-  const [isDragging, setIsDragging] = useState(false);
-  const left = dimensions.margins.left;
-
-  const handlePointerMove = useCallback(
-    (event: PointerEvent) => {
-      if (!isDragging || !onEnergyUpdate) return;
-      const svg = plotSvgRef.current;
-      if (!svg) return;
-      const rect = svg.getBoundingClientRect();
-      const x = event.clientX - rect.left;
-      const adjustedX = x - left;
-      const plotWidth =
-        dimensions.width - left - dimensions.margins.right;
-      if (adjustedX < 0 || adjustedX > plotWidth) return;
-      const newEnergy = scales.xScale.invert(adjustedX);
-      const roundedEnergy = Math.round(newEnergy * 100) / 100;
-      onEnergyUpdate(peakId, roundedEnergy);
-    },
-    [
-      isDragging,
-      onEnergyUpdate,
-      peakId,
-      scales.xScale,
-      left,
-      dimensions.width,
-      dimensions.margins.right,
-      plotSvgRef,
-    ],
-  );
-
-  const handlePointerUp = useCallback(() => {
-    setIsDragging(false);
-  }, []);
-
-  useEffect(() => {
-    if (!isDragging) return;
-    window.addEventListener("pointermove", handlePointerMove);
-    window.addEventListener("pointerup", handlePointerUp);
-    window.addEventListener("pointercancel", handlePointerUp);
-    return () => {
-      window.removeEventListener("pointermove", handlePointerMove);
-      window.removeEventListener("pointerup", handlePointerUp);
-      window.removeEventListener("pointercancel", handlePointerUp);
-    };
-  }, [isDragging, handlePointerMove, handlePointerUp]);
-
-  const handlePointerDown = (e: React.PointerEvent<SVGRectElement>) => {
-    if (!onEnergyUpdate) return;
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(true);
-  };
-
-  const fill = isSelected ? PEAK_COLORS.selected : PEAK_COLORS.unselected;
-  const outline = isDark
-    ? "rgba(248,250,252,0.94)"
-    : "rgba(15,23,42,0.88)";
-  const cursor = onEnergyUpdate
-    ? isDragging
-      ? "grabbing"
-      : "grab"
-    : "default";
 
   if (handlesOnlyWhenSelected && !isSelected) return null;
 
-  const handlePair = (centerY: number, key: string) => {
-    const hitTop = centerY - hitH / 2;
-    return (
-      <g key={key}>
-        <rect
-          x={xPos - hitPadX}
-          y={hitTop}
-          width={hitPadX * 2}
-          height={hitH}
-          fill="transparent"
-          cursor={cursor}
-          onPointerDown={handlePointerDown}
-          style={{ touchAction: "none" }}
-        />
-        <rect
-          x={xPos - pillW / 2}
-          y={centerY - pillH / 2}
-          width={pillW}
-          height={pillH}
-          rx={pillH / 2}
-          fill={fill}
-          stroke={outline}
-          strokeWidth={isSelected ? 2 : 1.5}
-          opacity={isDragging ? 0.92 : 1}
-          pointerEvents="none"
-        />
-      </g>
-    );
-  };
+  const outline = isDark
+    ? "rgba(248,250,252,0.94)"
+    : "rgba(15,23,42,0.88)";
 
   return (
-    <g style={{ pointerEvents: onEnergyUpdate ? "all" : "none" }}>
-      {handlePair(topCenterY, "top")}
-      {dualHandles ? handlePair(bottomCenterY, "bottom") : null}
-    </g>
+    <PinnedAxisMarker
+      energy={peak.energy}
+      xScale={scales.xScale}
+      dimensions={dimensions}
+      plotSvgRef={plotSvgRef}
+      isSelected={isSelected}
+      fill={PEAK_COLORS.unselected}
+      selectedFill={PEAK_COLORS.selected}
+      outline={outline}
+      railColor={undefined}
+      labelTop={undefined}
+      hitPadX={26}
+      onEnergyChange={
+        onEnergyUpdate ? (energy) => onEnergyUpdate(peakId, energy) : undefined
+      }
+    />
   );
 }


### PR DESCRIPTION
## Summary

Adds **client-side inspect pins** on the NEXAFS spectrum plot: click (inspect mode) to pin energy and per-trace values, draggable HTML popovers with copy actions, draggable axis grips, and fixes so pins work when zoomed. Pins are **not** persisted to the database.

## Changes

- `PinnedInspectPoint` type and `useInspectPins` hook for ephemeral pin state
- `InspectPinLayer`, `DraggablePlotPopover`, `PinnedAxisMarker`; `InteractivePeak` delegates to `PinnedAxisMarker`
- `SpectrumPlotInner`: full-plot transparent hit target, click-to-pin, SVG `eventToPlotCoords` for placement; `BrushZoom` `allowPlotInteractionsBelow` when x-zoom is active so the brush layer does not block inspect clicks
- Collapsible pin popovers (chevron); red grip/crosshair accent only while the handle is pressed/dragged
- `svgPlotPointer`: `eventToPlotCoords` accepts any event with `clientX`/`clientY`

## Test Plan

- [x] Tested locally
- [ ] Tested OAuth flow (if auth changes)
- [x] Tested on mobile (if UI changes)

## AI Role (required)

Choose one of the following and briefly justify it:

- [ ] Level 1: Mostly suggestions, tab completion, and minimal code generation
- [x] Level 2: Extensive code generation, but heavily managed; business and scientific logic was dictated by the contributor
- [ ] Level 3: Fully vibe coded; PRs using this level will likely be thrown away, but may contain nuggets a maintainer chooses to review

Validation: `bun run typecheck` and `bun run lint` (no new errors); production `next build` succeeded during development; manual plot checks for pin add/drag/zoom/collapse.

## Screenshots (if UI changes)

Before | After
--- | ---
N/A (new interaction) | Inspect pins with collapsible popovers and draggable grips on the spectrum plot
