### PR TITLE
docs: wiki contribution Git conventions (CONTRIBUTING + AGENTS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,19 @@ Global styling and Tailwind entry CSS.
 - `src/lib` and `src/utils` hold shared helpers; use `src/lib` when broader/purer, and `src/utils` for small widely reused helpers.
 - `src/styles` contains global styling only; avoid component-specific styling leakage into `globals.css`.
 
+## Contributor conventions (Git)
+
+Environment setup, PR checklist, and the full conventional-commit table live in **`CONTRIBUTING.md`**. Agents and contributors must still honor these **project conventions**:
+
+### Wiki-only work
+
+Wiki URLs under **`src/app/wiki`** (layouts and topic pages); shared doc chrome includes **`src/components/about/wiki-doc-shell.tsx`** and **`src/lib/wiki-doc-nav.ts`**.
+
+- **Branches:** use the **`wiki/`** prefix (`wiki/<short-kebab-description>`). Examples: `wiki/home-copy-edit`, `wiki/platform-features-clarity`.
+- **Commits:** on wiki-focused branches, every commit uses **`type(wiki): description`** per Conventional Commits (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`). Examples: `feat(wiki): add glossary anchor links`, `fix(wiki): correct schematic caption`.
+
+Duplicate prose and examples live under **`CONTRIBUTING.md`** — Wiki contributions; update both documents together when changing those rules.
+
 ## User administration (`/admin/users`)
 
 Users who hold an `AppRole` with `canManageUsers` open **User administration** from the account menu. The console supports:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Thank you for your interest in contributing to X-ray Atlas. This guide covers de
   - [GitHub OAuth](#github-oauth)
   - [Local OAuth Testing with ngrok](#local-oauth-testing-with-ngrok)
 - [Development Workflow](#development-workflow)
+- [Wiki contributions](#wiki-contributions)
 - [Code Style](#code-style)
 - [HeroUI v3 and UI components](#heroui-v3-and-ui-components)
 - [Git Workflow](#git-workflow)
@@ -426,6 +427,8 @@ docs(contributing): add ngrok setup guide
 refactor(plots): extract axis components
 ```
 
+Wiki-only work belongs on **`wiki/...` branches** with **`(wiki)` scope on every commit**; see [Wiki contributions](#wiki-contributions).
+
 ---
 
 ## HeroUI v3 and UI components
@@ -481,6 +484,8 @@ fix/36-passkey-invalid-character
 refactor/32-colocation-migration
 ```
 
+Wiki work uses the **`wiki/`** prefix and **`(wiki)`** commit scope throughout; see [Wiki contributions](#wiki-contributions).
+
 ### Using Graphite (Recommended)
 
 We use [Graphite](https://graphite.dev/) for stacked PRs and branch management.
@@ -527,6 +532,48 @@ gt restack
 # Using Git
 git fetch origin
 git rebase origin/main
+```
+
+---
+
+## Wiki contributions
+
+Educational and editorial work for the **Wiki** (`/wiki` routes under `src/app/wiki`, shared chrome such as `src/components/about/wiki-doc-shell.tsx`, and wiki-linked navigation) should stay easy to find in Git history and on Git hosting filters.
+
+### Branches
+
+Use the **`wiki/`** branch prefix for every wiki-focused PR:
+
+```
+wiki/<short-kebab-description>
+```
+
+Examples:
+
+```
+wiki/clarify-data-representation-page
+wiki/hero-schematic-caption
+wiki/contributions-guidance-copy
+```
+
+### Commits
+
+Use **Conventional Commits with scope `(wiki)`** for **every commit** on these branches (even chores and refactors touching only wiki surfaces):
+
+```
+<type>(wiki): description
+```
+
+Allowed types match the rest of the project (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`). Prefer the type that best matches the change; scope stays `wiki`.
+
+Examples:
+
+```bash
+feat(wiki): add platform-features section on instrumentation limits
+fix(wiki): correct NEXAFS schematic caption timing note
+docs(wiki): expand contributions page prerequisites
+refactor(wiki): extract wiki home hero layout fragment
+chore(wiki): align wiki nav labels with shell TOC
 ```
 
 ---


### PR DESCRIPTION
## Summary

Documents **wiki-only contribution conventions**: Git branches must use the `wiki/` prefix, and every commit on those branches must use Conventional Commits with scope **`(wiki)`**. Mirrors the rule set in **`CONTRIBUTING.md`** inside **`AGENTS.md`** so agents and contributors see it alongside project structure.

## Changes

- **CONTRIBUTING.md:** New "Wiki contributions" section (TOC entry, branch naming `wiki/<description>`, commit examples `feat(wiki)`, `fix(wiki)`, etc.); cross-links from Git workflow and commit message sections.
- **AGENTS.md:** New "Contributor conventions (Git)" with wiki paths (`src/app/wiki`, wiki-doc shell/nav), branch/commit rules, and instruction to keep both docs aligned.

## Test Plan

- [x] Tested locally
- [ ] Tested OAuth flow (if auth changes)
- [ ] Tested on mobile (if UI changes)

## AI Role (required)

Choose one of the following and briefly justify it:

- [ ] Level 1: Mostly suggestions, tab completion, and minimal code generation
- [x] Level 2: Extensive code generation, but heavily managed; business and scientific logic was dictated by the contributor
- [ ] Level 3: Fully vibe coded; PRs using this level will likely be thrown away, but may contain nuggets a maintainer chooses to review

If you selected Level 2 or Level 3, include at least one sentence describing how you validated correctness (tests, types, manual verification, scientific sanity checks).

Markdown-only change set; no runtime behavior; prose reviewed for consistency with intended wiki workflow.

## Screenshots (if UI changes)

Before | After
--- | ---
n/a | n/a
