### PR TITLE
fix(molecules): restore browse full card vs home carousel tile

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -15,7 +15,7 @@ import {
   InformationCircleIcon,
 } from "@heroicons/react/24/outline";
 import { MoleculeSearch } from "@/components/molecules/molecule-search";
-import { MoleculeCard } from "@/components/molecules/molecule-display";
+import { MoleculeDisplayCarouselTile } from "@/components/molecules/molecule-display";
 import { MoleculeCardSkeleton } from "@/components/feedback/loading-state";
 import { ErrorState } from "@/components/feedback/error-state";
 import { trpc } from "~/trpc/client";
@@ -202,7 +202,7 @@ function TopUpvotedMolecules() {
               }
               className="flex h-full min-h-0 w-full flex-1 cursor-pointer rounded-xl transition-[opacity,box-shadow] hover:opacity-[0.98]"
             >
-              <MoleculeCard molecule={molecule} variant="full" />
+              <MoleculeDisplayCarouselTile molecule={molecule} />
             </div>
           </div>
         ))}

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -15,7 +15,7 @@ import {
   InformationCircleIcon,
 } from "@heroicons/react/24/outline";
 import { MoleculeSearch } from "@/components/molecules/molecule-search";
-import { MoleculeDisplayCarouselTile } from "@/components/molecules/molecule-display";
+import { MoleculeCard } from "@/components/molecules/molecule-display";
 import { MoleculeCardSkeleton } from "@/components/feedback/loading-state";
 import { ErrorState } from "@/components/feedback/error-state";
 import { trpc } from "~/trpc/client";
@@ -202,7 +202,7 @@ function TopUpvotedMolecules() {
               }
               className="flex h-full min-h-0 w-full flex-1 cursor-pointer rounded-xl transition-[opacity,box-shadow] hover:opacity-[0.98]"
             >
-              <MoleculeDisplayCarouselTile molecule={molecule} />
+              <MoleculeCard molecule={molecule} variant="fullCarousel" />
             </div>
           </div>
         ))}

--- a/src/components/molecules/molecule-display.tsx
+++ b/src/components/molecules/molecule-display.tsx
@@ -376,9 +376,10 @@ interface MoleculeCardActionsProps {
   handleCopy: (text: string, label: string) => void;
   size?: "sm" | "md";
   /**
-   * When true, registry icons show only when the card container is at least `lg`; use with inline registry links beside the title below that breakpoint.
+   * `browse`: molecule browse / NEXAFS shells — always show InChI/SMILES copy buttons and registry favicons.
+   * `carousel`: home popular-molecule tiles — hide those controls until the card hits `@lg` width inside `@container`.
    */
-  registryIconsUseCardContainerBreakpoint?: boolean;
+  actionsLayout?: "browse" | "carousel";
 }
 
 export function MoleculeCardActions({
@@ -388,17 +389,25 @@ export function MoleculeCardActions({
   copiedText,
   handleCopy,
   size = "sm",
-  registryIconsUseCardContainerBreakpoint = false,
+  actionsLayout = "browse",
 }: MoleculeCardActionsProps) {
   const iconClass = size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4";
   const textClass = size === "sm" ? "text-[10px]" : "text-xs";
+  const inchiSmilesRowClass =
+    actionsLayout === "carousel"
+      ? "hidden min-w-0 flex-row flex-wrap items-center gap-2 @lg:flex"
+      : "flex min-w-0 flex-row flex-wrap items-center gap-2";
+  const registryRowClass =
+    actionsLayout === "carousel"
+      ? "hidden min-w-0 flex-row flex-wrap items-center gap-2 @lg:flex"
+      : "flex min-w-0 flex-row flex-wrap items-center gap-2";
   return (
     <div
       className="flex w-full min-w-0 flex-row flex-wrap items-center gap-x-4 gap-y-2"
       onClick={(e) => e.stopPropagation()}
       role="group"
     >
-      <div className="hidden min-w-0 flex-row flex-wrap items-center gap-2 @lg:flex">
+      <div className={inchiSmilesRowClass}>
         {molecule.InChI ? (
           <Tooltip delay={0}>
             <Button
@@ -442,12 +451,7 @@ export function MoleculeCardActions({
           </Tooltip>
         ) : null}
       </div>
-      <div
-        className={cn(
-          "min-w-0 flex-row flex-wrap items-center gap-2",
-          registryIconsUseCardContainerBreakpoint ? "hidden @lg:flex" : "flex",
-        )}
-      >
+      <div className={registryRowClass}>
         <MoleculeRegistryFaviconLinks casUrl={casUrl} pubChemUrl={pubChemUrl} />
       </div>
     </div>
@@ -839,6 +843,239 @@ export const FullCard = memo(function FullCard({
   const [imageModalOpen, setImageModalOpen] = useState(false);
 
   return (
+    <Card className="group border-border-default hover:border-border-strong hover:border-accent/30 dark:border-border-default dark:hover:border-border-strong flex h-full w-full flex-col overflow-hidden rounded-2xl border bg-zinc-50 shadow-sm transition-[border-color,box-shadow] duration-200 hover:shadow-md lg:flex-row dark:bg-zinc-800">
+      <div
+        className="group/image relative flex h-52 w-full shrink-0 overflow-hidden rounded-lg bg-white lg:h-auto lg:min-h-[260px] lg:w-[min(42%,320px)] lg:max-w-[360px] dark:bg-black"
+        aria-hidden
+      >
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setImageModalOpen(true);
+          }}
+          className="flex h-full w-full cursor-pointer items-center justify-center p-4"
+          aria-label="View molecule structure"
+        >
+          {hasImage ? (
+            <div className="pointer-events-none flex h-full w-full items-center justify-center">
+              <MoleculeImageSVG
+                imageUrl={props.molecule.imageUrl ?? ""}
+                name={props.primaryName}
+                className="h-full w-full motion-safe:transition-[transform,opacity] motion-safe:duration-300 motion-safe:group-hover/image:scale-105 [&_svg]:h-full [&_svg]:w-full [&_svg]:object-contain"
+              />
+            </div>
+          ) : (
+            <div
+              className={`flex h-full w-full items-center justify-center bg-linear-to-br ${previewGradient}`}
+            >
+              <Atom
+                className="h-14 w-14 text-white/80 drop-shadow-lg motion-safe:transition-[transform,opacity] motion-safe:duration-300 motion-safe:group-hover/image:scale-110 motion-safe:group-hover/image:opacity-100"
+                strokeWidth={1}
+                aria-hidden
+              />
+            </div>
+          )}
+        </button>
+        <div
+          className="absolute inset-x-0 top-0 flex justify-center p-2"
+          onClick={(e) => e.stopPropagation()}
+          aria-hidden
+        >
+          <span
+            className="shrink-0 rounded border border-slate-200 bg-slate-100 px-1.5 py-0.5 font-mono text-xs text-slate-800 tabular-nums dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+            title="Chemical formula"
+          >
+            {props.molecule.chemicalFormula}
+          </span>
+        </div>
+        <div
+          className="absolute inset-x-0 bottom-0 flex justify-end rounded-b-lg bg-white/90 px-2 py-2 text-slate-900 backdrop-blur-md dark:bg-black/60 dark:text-slate-100"
+          onClick={(e) => e.stopPropagation()}
+          aria-hidden
+        >
+          <ContributorsOrEmpty users={avatarUsers} overlay />
+        </div>
+      </div>
+      <MoleculeImageModal
+        isOpen={imageModalOpen}
+        onClose={() => setImageModalOpen(false)}
+        hasImage={hasImage}
+        imageUrl={props.molecule.imageUrl ?? ""}
+        primaryName={props.primaryName}
+        chemicalFormula={props.molecule.chemicalFormula}
+        previewGradient={previewGradient}
+      />
+      <Card.Content className="flex min-w-0 flex-1 flex-col gap-3 p-4">
+        <div onClick={(e) => e.stopPropagation()}>
+          <Link
+            href={`/molecules/${canonicalMoleculeSlugFromView(props.molecule)}`}
+            className="text-text-primary hover:text-accent dark:hover:text-accent-light line-clamp-3 text-lg leading-tight font-bold wrap-break-word transition-colors"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {props.primaryName}
+          </Link>
+        </div>
+        {props.orderedSynonyms.length > 0 ? (
+          <div
+            className="min-w-0 overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <SynonymChipsWithPopup
+              synonyms={props.orderedSynonyms}
+              maxSynonyms={3}
+            />
+          </div>
+        ) : null}
+        {props.molecule.casNumber ? (
+          <div className="min-w-0" onClick={(e) => e.stopPropagation()}>
+            <Tooltip delay={0}>
+              <Tooltip.Trigger>
+                <button
+                  type="button"
+                  aria-label="Copy CAS number"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    props.handleCopy(props.molecule.casNumber ?? "", "CAS");
+                  }}
+                  className={`focus-visible:ring-accent inline-flex items-center gap-2 rounded-md px-2 py-1 font-mono text-xs tabular-nums transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 ${
+                    props.copiedText === "CAS"
+                      ? "bg-info/30 text-info dark:bg-info/40 dark:text-info-light"
+                      : "bg-info/20 text-info dark:bg-info/30 dark:text-info-light"
+                  }`}
+                >
+                  <Copy className="h-4 w-4 shrink-0" aria-hidden />
+                  CAS {props.molecule.casNumber}
+                </button>
+              </Tooltip.Trigger>
+              <Tooltip.Content placement="top">
+                {props.copiedText === "CAS" ? "Copied!" : "Copy CAS number"}
+              </Tooltip.Content>
+            </Tooltip>
+          </div>
+        ) : null}
+        {props.molecule.iupacName ? (
+          <div
+            className="min-w-0 flex-1 text-xs leading-relaxed"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ScrollShadow
+              className="max-h-[3.25em] min-h-0 overflow-x-hidden overflow-y-auto"
+              hideScrollBar
+            >
+              <p className="text-text-tertiary wrap-break-word">
+                {props.molecule.iupacName}
+              </p>
+            </ScrollShadow>
+          </div>
+        ) : null}
+        <div className="min-w-0 py-1" onClick={(e) => e.stopPropagation()}>
+          <MoleculeCardActions
+            molecule={props.molecule}
+            pubChemUrl={props.pubChemUrl}
+            casUrl={props.casUrl}
+            copiedText={props.copiedText}
+            handleCopy={props.handleCopy}
+            size="sm"
+          />
+        </div>
+        {(props.molecule.moleculeTags?.length ?? 0) > 0 ? (
+          <div onClick={(e) => e.stopPropagation()}>
+            <MoleculeTags molecule={props.molecule} />
+          </div>
+        ) : null}
+        <footer
+          className="mt-auto flex flex-wrap items-center gap-3 border-t border-zinc-200 pt-2 dark:border-zinc-600"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <span
+            className="flex items-center gap-1 text-xs text-sky-500 tabular-nums"
+            title="Views"
+          >
+            <Eye className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            {props.molecule.viewCount ?? 0}
+          </span>
+          <div
+            className={`flex items-center gap-1 text-xs tabular-nums ${
+              props.realtimeUserHasUpvoted
+                ? "font-medium text-pink-500"
+                : "text-text-tertiary"
+            }`}
+          >
+            {props.molecule.id && props.isSignedIn ? (
+              <Button
+                size="sm"
+                variant="secondary"
+                isIconOnly
+                aria-label={
+                  props.realtimeUserHasUpvoted ? "Unfavorite" : "Favorite"
+                }
+                isDisabled={props.favoriteMutation.isPending}
+                onPress={props.handleFavorite}
+                className={`focus-visible:ring-accent -m-1 ${
+                  props.realtimeUserHasUpvoted
+                    ? "text-pink-500"
+                    : "text-text-tertiary"
+                }`}
+              >
+                <Heart
+                  className={`h-3.5 w-3.5 shrink-0 ${
+                    props.realtimeUserHasUpvoted
+                      ? "fill-pink-500 text-pink-500"
+                      : ""
+                  }`}
+                  aria-hidden
+                />
+              </Button>
+            ) : (
+              <Heart
+                className={`h-3.5 w-3.5 shrink-0 ${
+                  props.realtimeUserHasUpvoted
+                    ? "fill-pink-500 text-pink-500"
+                    : ""
+                }`}
+                aria-hidden
+              />
+            )}
+            {props.realtimeUpvoteCount}
+          </div>
+          <span
+            className="flex items-center gap-1 text-xs text-amber-500 tabular-nums"
+            title="Datasets"
+          >
+            <Database className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            {experimentCount >= 1000
+              ? `${(experimentCount / 1000).toFixed(1)}k`
+              : experimentCount}
+          </span>
+        </footer>
+      </Card.Content>
+    </Card>
+  );
+});
+
+export const FullCardCarousel = memo(function FullCardCarousel({
+  props,
+}: {
+  props: MoleculeCardProps;
+}) {
+  const fromContributors =
+    (props.molecule.contributors?.length ?? 0) > 0
+      ? props.molecule.contributors!.map((c) => c.user)
+      : [];
+  const avatarUsers: UserWithOrcid[] =
+    fromContributors.length > 0
+      ? fromContributors
+      : props.molecule.createdBy
+        ? [props.molecule.createdBy]
+        : [];
+  const previewGradient = getPreviewGradient(props.molecule);
+  const hasImage = Boolean(props.molecule.imageUrl?.trim());
+  const experimentCount = props.molecule.experimentCount ?? 0;
+
+  const [imageModalOpen, setImageModalOpen] = useState(false);
+
+  return (
     <Card className="group border-border-default hover:border-border-strong hover:border-accent/30 dark:border-border-default dark:hover:border-border-strong @container flex h-full w-full flex-col overflow-hidden rounded-2xl border bg-zinc-50 shadow-sm transition-[border-color,box-shadow] duration-200 hover:shadow-md @lg:flex-row dark:bg-zinc-800">
       <div
         className="group/image relative flex h-52 w-full shrink-0 overflow-hidden rounded-lg bg-white @lg:h-auto @lg:min-h-[260px] @lg:w-[min(42%,320px)] @lg:max-w-[360px] dark:bg-black"
@@ -987,7 +1224,7 @@ export const FullCard = memo(function FullCard({
             copiedText={props.copiedText}
             handleCopy={props.handleCopy}
             size="sm"
-            registryIconsUseCardContainerBreakpoint
+            actionsLayout="carousel"
           />
         </div>
         {(props.molecule.moleculeTags?.length ?? 0) > 0 ? (
@@ -1991,6 +2228,16 @@ export const HeaderCard = memo(function HeaderCard({
   );
 });
 
+/**
+ * Renders a molecule summary card for grids, carousels, and headers.
+ *
+ * @param molecule - Display DTO including identifiers, tags, and engagement fields used by the card body.
+ * @param onEdit - Optional callback wired when the shell exposes edit affordances (for example header variant).
+ * @param variant - `full`: molecule browse grid (`lg` viewport breakpoints, full identifier row). `fullCarousel`: home carousel tiles (`@container` / `@lg` with condensed chrome). `compact`: browse list rows. `header`: molecule detail header editor shell.
+ * @param enableRealtime - When true, subscribes for live favorite counts and heart state for `molecule.id`.
+ * @param canEdit - Overrides edit capability when the shell needs a fixed value independent of session.
+ * @param isSignedIn - Overrides signed-in detection for favorite actions when embedding outside normal session context.
+ */
 export const MoleculeCard = memo(function MoleculeCard({
   molecule,
   onEdit,
@@ -2001,7 +2248,7 @@ export const MoleculeCard = memo(function MoleculeCard({
 }: {
   molecule: MoleculeView;
   onEdit?: () => void;
-  variant?: "full" | "compact" | "header";
+  variant?: "full" | "fullCarousel" | "compact" | "header";
   enableRealtime?: boolean;
   canEdit?: boolean;
   isSignedIn?: boolean;
@@ -2104,6 +2351,7 @@ export const MoleculeCard = memo(function MoleculeCard({
   const cardProps = resolveMolecule(molecule, context);
   if (variant === "compact") return <CompactCard props={cardProps} />;
   if (variant === "header") return <HeaderCard props={cardProps} />;
+  if (variant === "fullCarousel") return <FullCardCarousel props={cardProps} />;
   return <FullCard props={cardProps} />;
 });
 
@@ -2161,6 +2409,28 @@ export function MoleculeDisplayCompact({
     <MoleculeCard
       molecule={molecule}
       variant="compact"
+      enableRealtime={enableRealtime}
+    />
+  );
+}
+
+/**
+ * Renders the home carousel molecule tile layout (`fullCarousel`); use `MoleculeDisplay` / default `MoleculeCard` on browse grids.
+ *
+ * @param molecule - Same `MoleculeView` contract as other molecule cards.
+ * @param enableRealtime - Passed through to `MoleculeCard`; disables realtime hooks when false (for example static previews).
+ */
+export function MoleculeDisplayCarouselTile({
+  molecule,
+  enableRealtime = true,
+}: {
+  molecule: MoleculeView;
+  enableRealtime?: boolean;
+}) {
+  return (
+    <MoleculeCard
+      molecule={molecule}
+      variant="fullCarousel"
       enableRealtime={enableRealtime}
     />
   );

--- a/src/components/molecules/molecule-display.tsx
+++ b/src/components/molecules/molecule-display.tsx
@@ -2413,25 +2413,3 @@ export function MoleculeDisplayCompact({
     />
   );
 }
-
-/**
- * Renders the home carousel molecule tile layout (`fullCarousel`); use `MoleculeDisplay` / default `MoleculeCard` on browse grids.
- *
- * @param molecule - Same `MoleculeView` contract as other molecule cards.
- * @param enableRealtime - Passed through to `MoleculeCard`; disables realtime hooks when false (for example static previews).
- */
-export function MoleculeDisplayCarouselTile({
-  molecule,
-  enableRealtime = true,
-}: {
-  molecule: MoleculeView;
-  enableRealtime?: boolean;
-}) {
-  return (
-    <MoleculeCard
-      molecule={molecule}
-      variant="fullCarousel"
-      enableRealtime={enableRealtime}
-    />
-  );
-}


### PR DESCRIPTION
## Summary

Restores the molecule browse grid "full" card layout that regressed when carousel-focused markup landed on the shared `FullCard` (commit ed2ad53). Home popular molecules keep the narrow `@container` carousel tile via a dedicated `fullCarousel` variant.

## Changes

- **Browse / default `MoleculeDisplay`**: `FullCard` again uses viewport `lg:` breakpoints, full CAS/IUPAC/actions chrome without carousel-only hiding.
- **Home carousel**: `MoleculeCard variant="fullCarousel"` renders `FullCardCarousel` (container-query layout + inline registry favicons beside the title on narrow tiles).
- **`MoleculeCardActions`**: `actionsLayout` (`browse` | `carousel`) replaces the old `registryIconsUseCardContainerBreakpoint` flag.

## Verification

- `bun run typecheck`
- `bun run lint` (existing repo warnings only)

## AI Role

Level 2: AI-assisted implementation following repo conventions; human-directed scope and review.