### PR TITLE
feat(wiki): align about page with canonical FAIR branding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 /.pnp
 .pnp.js
 
+# temporary files
+/tmp
+
 # testing
 /coverage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,13 @@ Global styling and Tailwind entry CSS.
 - `src/lib` and `src/utils` hold shared helpers; use `src/lib` when broader/purer, and `src/utils` for small widely reused helpers.
 - `src/styles` contains global styling only; avoid component-specific styling leakage into `globals.css`.
 
+## Branding source of truth
+
+- `src/app/brand.ts` is the canonical source of truth for site identity, mission language, and attribution metadata.
+- Reuse exported values from `brand.ts` in metadata, page copy, OpenGraph/Twitter tags, and shared UI surfaces instead of duplicating branding strings.
+- Use `site.name` for reader-facing UI copy and `site.applicationName` only for machine-oriented labels that intentionally require that variant.
+- Keep host and institutional attribution aligned to `attribution.*` values, and prefer mission variants in `mission.*` based on context (`heroShort`, `canonical`, `technical`, `stewardship`, `seoDescription`, `ogTitle`).
+
 ## Contributor conventions (Git)
 
 Environment setup, PR checklist, and the full conventional-commit table live in **`CONTRIBUTING.md`**. Agents and contributors must still honor these **project conventions**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,10 +206,10 @@ Implementation reference: `src/server/api/routers/admin.ts` (`updateUser`, `setU
 - For substantive UI changes, use the project's browser verification tooling when available instead of relying only on static code review.
 - For HeroUI upgrades or broad component migrations, use the HeroUI migration MCP and migration guide during planning and implementation; browser-verify interactive flows; after navigation, wait for content to settle on slow pages before screenshots; use subagents for parallel tasks when that reduces context load.
 - Prefer `bun run lint` (ESLint via `bunx eslint .`) together with `bun run typecheck` when validating changes; `bun run check` runs `next lint` plus `tsc`, which can diverge from the ESLint-only `lint` script.
-- For the account profile dropdown, separate developer-oriented items from standard user actions with a visual divider; group profile, dashboard, and create-team together, and place admin-only entries such as **User administration** in their own section.
-- For admin consoles such as `/admin/users`, prefer a multi-surface layout over a single dense panel; when search is central, show Command+K using HeroUI `Kbd` with `Kbd.Abbr` for the modifier and `Kbd.Content` for the key.
-- When a destructive control is not allowed (for example deleting a protected user), keep the control visible in a disabled or muted state rather than removing it so users see a consistent action strip.
-- On `/admin/users`, size table columns for readability without excess width; hide raw id in the default view and offer copy-id; keep per-row action icons aligned with their column.
+- For the account profile dropdown, separate developer-oriented items from standard user actions with a visual divider; group profile, dashboard, and create-team together, and place admin-only entries such as **User administration** in their own section. For admin consoles such as `/admin/users`, prefer a multi-surface layout over a single dense panel; when search is central, show Command+K using HeroUI `Kbd` with `Kbd.Abbr` for the modifier and `Kbd.Content` for the key.
+- When a destructive control is not allowed (for example deleting a protected user), keep the control visible in a disabled or muted state rather than removing it so users see a consistent action strip. On `/admin/users`, size table columns for readability without excess width; hide raw id in the default view and offer copy-id; keep per-row action icons aligned with their column.
+- When the user asks whether something already exists without pointing at this repository, interpret the question as whether an adoptable framework, product, or library exists, not only whether the current codebase already implements it.
+- Keep `google-site-verification` and similar search-indexing ownership tokens in validated environment configuration rather than committing secret values into source files.
 
 ## Learned Workspace Facts
 

--- a/src/app/(home)/loading.tsx
+++ b/src/app/(home)/loading.tsx
@@ -3,6 +3,7 @@ import { MoleculeSearch } from "@/components/molecules/molecule-search";
 import { DefaultButton as Button } from "@/components/ui/button";
 import Link from "next/link";
 import { Search, Upload } from "lucide-react";
+import { mission, site } from "~/app/brand";
 
 const CONTENT_MAX_WIDTH = "max-w-7xl";
 
@@ -13,10 +14,10 @@ export default function HomeLoading() {
         <div className={`mx-auto w-full ${CONTENT_MAX_WIDTH} px-4`}>
           <div className="mx-auto max-w-4xl text-center">
             <h1 className="mb-4 text-4xl font-bold text-gray-900 sm:text-5xl md:text-6xl dark:text-gray-100">
-              X-ray Atlas
+              {site.name}
             </h1>
             <p className="mb-8 text-lg text-gray-600 sm:text-xl dark:text-gray-400">
-              Advancing material research through collaborative data.
+              {mission.heroShort}
             </p>
             <div className="mb-8 flex justify-center">
               <MoleculeSearch

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -21,6 +21,7 @@ import { ErrorState } from "@/components/feedback/error-state";
 import { trpc } from "~/trpc/client";
 import { useRouter } from "next/navigation";
 import { canonicalMoleculeSlugFromView } from "~/lib/molecule-slug";
+import { mission, site } from "~/app/brand";
 
 /**
  * Maps viewport width to how many full molecule cards render per carousel page.
@@ -341,11 +342,10 @@ export default function HomePage() {
               <WikiQuickStartChip />
             </div>
             <h1 className="text-foreground mb-4 text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
-              X-ray Atlas
+              {site.name}
             </h1>
             <p className="text-muted mx-auto mb-8 max-w-lg text-base leading-relaxed sm:text-lg">
-              Open NEXAFS and X-ray spectroscopy data—search molecules, compare
-              spectra, cite with confidence.
+              {mission.heroShort}
             </p>
             <div className="mb-7 flex justify-center">
               <MoleculeSearch

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -13,6 +13,10 @@ import {
   AcademicCapIcon,
   BookOpenIcon,
   InformationCircleIcon,
+  MagnifyingGlassIcon,
+  LockOpenIcon,
+  ArrowsRightLeftIcon,
+  ArrowPathIcon,
   RectangleStackIcon,
   SparklesIcon,
   UserGroupIcon,
@@ -52,6 +56,33 @@ const aboutResourceCards = [
     description:
       "Guidance for dataset contributors, metadata expectations, attribution, and scientific reproducibility practices.",
     icon: ArrowTopRightOnSquareIcon,
+  },
+] as const;
+
+const fairPrinciples = [
+  {
+    title: "Findable",
+    description:
+      "Molecule records, spectra, and experimental metadata are indexed for search by identifiers, chemical context, edge, instrument, facility, and quality-oriented filters.",
+    icon: MagnifyingGlassIcon,
+  },
+  {
+    title: "Accessible",
+    description:
+      "Datasets are available through the web interface and API-based workflows so researchers can retrieve records and associated context across computational environments.",
+    icon: LockOpenIcon,
+  },
+  {
+    title: "Interoperable",
+    description:
+      "Records preserve structured molecular, experimental, and provenance metadata designed for integration with analysis pipelines and external research tooling.",
+    icon: ArrowsRightLeftIcon,
+  },
+  {
+    title: "Reusable",
+    description:
+      "Contribution workflows emphasize attribution, provenance, and citable context so data can be interpreted and reused with clear scientific traceability.",
+    icon: ArrowPathIcon,
   },
 ] as const;
 
@@ -143,12 +174,52 @@ export default async function AboutPage() {
           <h1 className="text-foreground mb-2 text-4xl font-bold sm:text-5xl">
             About {site.name}
           </h1>
-          <p className="text-muted mx-auto max-w-3xl text-lg">
+          <p className="text-muted mx-auto max-w-4xl text-left text-base leading-relaxed sm:text-lg">
             {mission.canonical}
           </p>
         </div>
 
         <div className="space-y-12">
+          <section>
+            <h2 className="text-foreground mb-4 text-2xl font-semibold">
+              FAIR data alignment
+            </h2>
+            <div className="space-y-4">
+              <p className="text-muted">
+                {site.name} aligns with the FAIR guiding principles for
+                scientific data stewardship.
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {fairPrinciples.map((principle) => (
+                  <article
+                    key={principle.title}
+                    className="border-border bg-surface rounded-xl border p-4"
+                  >
+                    <div className="mb-2 flex items-center gap-2">
+                      <principle.icon className="text-accent h-5 w-5" />
+                      <h3 className="text-foreground text-lg font-semibold">
+                        {principle.title}
+                      </h3>
+                    </div>
+                    <p className="text-muted text-sm">{principle.description}</p>
+                  </article>
+                ))}
+              </div>
+              <p className="text-muted">
+                FAIR reference:{" "}
+                <Link
+                  href="https://www.nature.com/articles/sdata201618"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground hover:text-accent underline-offset-2 hover:underline"
+                >
+                  Wilkinson et al., The FAIR Guiding Principles for scientific
+                  data management and stewardship (Scientific Data, 2016)
+                </Link>
+              </p>
+            </div>
+          </section>
+
           <section>
             <h2 className="text-foreground mb-4 flex items-center gap-2 text-2xl font-semibold">
               <InformationCircleIcon className="text-accent h-6 w-6" />
@@ -379,60 +450,6 @@ export default async function AboutPage() {
             </div>
           </section>
 
-          <section>
-            <h2 className="text-foreground mb-4 text-2xl font-semibold">
-              FAIR data alignment
-            </h2>
-            <div className="text-muted space-y-4">
-              <p>
-                X-ray Atlas aligns with the FAIR guiding principles for
-                scientific data stewardship: findability, accessibility,
-                interoperability, and reusability.
-              </p>
-              <p>
-                <span className="text-foreground font-semibold">Findable:</span>{" "}
-                molecule records, spectra, and experimental metadata are indexed
-                for search by identifiers, chemical context, edge, instrument,
-                facility, and quality-oriented filters.
-              </p>
-              <p>
-                <span className="text-foreground font-semibold">
-                  Accessible:
-                </span>{" "}
-                datasets are available through the web interface and API-based
-                workflows so researchers can retrieve records and associated
-                context across computational environments.
-              </p>
-              <p>
-                <span className="text-foreground font-semibold">
-                  Interoperable:
-                </span>{" "}
-                records preserve structured molecular, experimental, and
-                provenance metadata designed for integration with analysis
-                pipelines and external research tooling.
-              </p>
-              <p>
-                <span className="text-foreground font-semibold">
-                  Reusable:
-                </span>{" "}
-                contribution workflows emphasize attribution, provenance, and
-                citable context so data can be interpreted and reused with clear
-                scientific traceability.
-              </p>
-              <p>
-                FAIR reference:{" "}
-                <Link
-                  href="https://www.nature.com/articles/sdata201618"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-foreground hover:text-accent underline-offset-2 hover:underline"
-                >
-                  Wilkinson et al., The FAIR Guiding Principles for scientific
-                  data management and stewardship (Scientific Data, 2016)
-                </Link>
-              </p>
-            </div>
-          </section>
         </div>
       </div>
     </div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { api } from "~/trpc/server";
 import { ORCIDIcon } from "~/components/icons";
+import { attribution, mission, site } from "~/app/brand";
 import {
   ArrowTopRightOnSquareIcon,
   AcademicCapIcon,
@@ -18,9 +19,9 @@ import {
 } from "@heroicons/react/24/outline";
 
 export const metadata: Metadata = {
-  title: "About Xray Atlas",
+  title: `About ${site.name}`,
   description:
-    "Learn the mission, data scope, and scientific workflows supported by the Xray Atlas NEXAFS and X-ray spectroscopy database.",
+    `Learn how ${site.name} supports FAIR-aligned spectroscopy discovery, attribution, and reuse across the synchrotron community.`,
 };
 
 const aboutResourceCards = [
@@ -140,18 +141,10 @@ export default async function AboutPage() {
       <div className="mx-auto max-w-4xl">
         <div className="mb-12 space-y-4 text-center">
           <h1 className="text-foreground mb-2 text-4xl font-bold sm:text-5xl">
-            About X-ray Atlas
+            About {site.name}
           </h1>
           <p className="text-muted mx-auto max-w-3xl text-lg">
-            X-ray Atlas is an open NEXAFS and X-ray spectroscopy database that
-            helps researchers discover, compare, and reuse molecule-resolved
-            spectra with rich experimental metadata, facility provenance, and
-            reproducible contribution workflows.
-          </p>
-          <p className="text-muted mx-auto max-w-3xl text-base">
-            Our mission is to accelerate materials, chemistry, and soft-matter
-            research by connecting high-quality spectroscopy datasets with the
-            context needed for scientific interpretation and citation.
+            {mission.canonical}
           </p>
         </div>
 
@@ -182,7 +175,7 @@ export default async function AboutPage() {
               </p>
               <div className="border-border bg-surface rounded-xl border p-4">
                 <h3 className="text-foreground mb-3 text-lg font-semibold">
-                  Hosted by
+                  Hosted by {attribution.lab}
                 </h3>
                 {collaboratorsData.hosts.length > 0 ? (
                   <ul className="space-y-2 text-sm">
@@ -382,6 +375,61 @@ export default async function AboutPage() {
                 The mission is practical and scientific: make high-quality
                 spectroscopy data easier to find, easier to trust, and easier to
                 cite.
+              </p>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-foreground mb-4 text-2xl font-semibold">
+              FAIR data alignment
+            </h2>
+            <div className="text-muted space-y-4">
+              <p>
+                X-ray Atlas aligns with the FAIR guiding principles for
+                scientific data stewardship: findability, accessibility,
+                interoperability, and reusability.
+              </p>
+              <p>
+                <span className="text-foreground font-semibold">Findable:</span>{" "}
+                molecule records, spectra, and experimental metadata are indexed
+                for search by identifiers, chemical context, edge, instrument,
+                facility, and quality-oriented filters.
+              </p>
+              <p>
+                <span className="text-foreground font-semibold">
+                  Accessible:
+                </span>{" "}
+                datasets are available through the web interface and API-based
+                workflows so researchers can retrieve records and associated
+                context across computational environments.
+              </p>
+              <p>
+                <span className="text-foreground font-semibold">
+                  Interoperable:
+                </span>{" "}
+                records preserve structured molecular, experimental, and
+                provenance metadata designed for integration with analysis
+                pipelines and external research tooling.
+              </p>
+              <p>
+                <span className="text-foreground font-semibold">
+                  Reusable:
+                </span>{" "}
+                contribution workflows emphasize attribution, provenance, and
+                citable context so data can be interpreted and reused with clear
+                scientific traceability.
+              </p>
+              <p>
+                FAIR reference:{" "}
+                <Link
+                  href="https://www.nature.com/articles/sdata201618"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground hover:text-accent underline-offset-2 hover:underline"
+                >
+                  Wilkinson et al., The FAIR Guiding Principles for scientific
+                  data management and stewardship (Scientific Data, 2016)
+                </Link>
               </p>
             </div>
           </section>

--- a/src/app/brand.ts
+++ b/src/app/brand.ts
@@ -1,0 +1,110 @@
+/**
+ * Canonical brand and mission strings for X-ray Atlas.
+ *
+ * Usage convention mirrors CSS custom properties or i18n key paths:
+ *   brand.mission.heroShort  -> "mission.hero-short"
+ *   brand.mission.canonical  -> "mission.canonical"
+ *
+ * All copy here is the single source of truth. Consume these strings
+ * in page components, metadata, OG tags, and documentation rather than
+ * duplicating copy across files.
+ *
+ * tmp/ status: pending promotion to src/lib/brand.ts
+ */
+
+// ---------------------------------------------------------------------------
+// Site identity
+// ---------------------------------------------------------------------------
+
+export const site = {
+    name: "X-ray Atlas",
+    url: "https://xrayatlas.wsu.edu",
+    applicationName: "Xray Atlas",
+  } as const;
+  
+  // ---------------------------------------------------------------------------
+  // Attribution
+  // WSU Carbon Lab hosts and maintains the database. The platform serves the
+  // broader synchrotron community but attribution to the originating lab is
+  // preserved throughout.
+  // ---------------------------------------------------------------------------
+  
+  export const attribution = {
+    lab: "WSU Carbon Lab",
+    labFull: "Washington State University Carbon Lab",
+    labUrl: "https://labs.wsu.edu/carbon/",
+    pi: "Brian Collins",
+    piTitle: "Prof. Brian Collins",
+    institution: "Washington State University",
+    institutionAbbr: "WSU",
+  } as const;
+  
+  // ---------------------------------------------------------------------------
+  // Mission strings
+  // Organized by context and audience. Prefer the shortest variant that is
+  // still accurate for the given surface area.
+  // ---------------------------------------------------------------------------
+  
+  export const mission = {
+    /**
+     * Hero short — homepage subheading, README tagline, social card fallback.
+     * Three declarative statements. No elaboration.
+     */
+    heroShort: "Search spectra. Trace provenance. Cite with confidence.",
+  
+    /**
+     * Hero long — homepage hero when space allows a second line, or any
+     * surface that benefits from a framing sentence before the call to action.
+     */
+    heroLong:
+      "X-ray spectroscopy data that belongs to the community that made it. Search spectra. Trace provenance. Cite with confidence.",
+  
+    /**
+     * Canonical — the definitive mission statement for the platform.
+     * Audience: any reader. Tone: clear, institutional, community-oriented.
+     * Use on the about page opening, grant language, and press materials.
+     */
+    canonical:
+      "X-ray Atlas is an open database for NEXAFS and X-ray absorption spectroscopy, built to make high-quality spectroscopy data findable, attributable, and reusable at the scale the field requires. Hosted by the WSU Carbon Lab and developed in collaboration with the synchrotron science community, the platform grounds every contributed spectrum in its experimental context and preserves contributor attribution across the full data lifecycle.",
+  
+    /**
+     * Technical — for API docs, developer onboarding, and methods sections
+     * in publications. Audience: researchers and engineers who want to know
+     * what the system actually does before using it.
+     */
+    technical:
+      "X-ray Atlas provides a queryable, API-accessible repository for NEXAFS and X-ray absorption spectroscopy datasets. Each record links molecular identifiers, spectral traces, experimental conditions, facility provenance, and contributor attribution in a structured schema aligned with FAIR data principles. The platform assigns persistent identifiers to contributed records and exposes machine-readable endpoints designed for integration into analysis pipelines, reference databases, and AI-assisted discovery workflows.",
+  
+    /**
+     * Stewardship — for grant applications, data management plans, and
+     * institutional communications. Emphasizes obligation, community
+     * infrastructure, and long-term data integrity.
+     */
+    stewardship:
+      "X-ray Atlas operates as community infrastructure for the synchrotron science community, with an explicit commitment to preserving experimental context and contributor attribution across the full data lifecycle. Every spectrum in the database carries its provenance forward — edge selection, sample geometry, instrument, facility, and originating researcher — because scientific reproducibility depends on that context remaining accessible alongside the data itself. The platform is maintained by the WSU Carbon Lab and developed in ongoing collaboration with researchers at ALS, NSLS-II, SSRL, and affiliated institutions, under open data licensing that treats publicly funded measurements as a shared community resource.",
+  
+    /**
+     * SEO description — used in <meta name="description"> and OG/Twitter
+     * description tags. ~155 characters, keyword-dense, no truncation risk.
+     */
+    seoDescription:
+      "Open NEXAFS and X-ray absorption spectroscopy database. Search molecules, compare spectra, and cite data with full experimental provenance. Hosted by the WSU Carbon Lab.",
+  
+    /**
+     * OG title — used in OpenGraph and Twitter card titles.
+     */
+    ogTitle: "X-ray Atlas | WSU Carbon Lab",
+  } as const;
+  
+  // ---------------------------------------------------------------------------
+  // Composite export for convenience
+  // ---------------------------------------------------------------------------
+  
+  export const brand = {
+    site,
+    attribution,
+    mission,
+  } as const;
+  
+  export default brand;
+  

--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,10 +1,12 @@
+import { site } from "~/app/brand";
+
 export default function Head() {
   return (
     <>
       <link
         rel="search"
         type="application/opensearchdescription+xml"
-        title="Xray Atlas Molecule Search"
+        title={`${site.applicationName} Molecule Search`}
         href="/opensearch.xml"
       />
     </>

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -1,83 +1,83 @@
 import { type Metadata } from "next";
+import { attribution, mission, site } from "~/app/brand";
 
 export const siteMetadata: Metadata = {
-  metadataBase: new URL("https://xrayatlas.wsu.edu"),
+  metadataBase: new URL(site.url),
   alternates: {
     canonical: "/",
   },
   title: {
-    template: "%s | Xray Atlas",
-    default: "Xray Atlas",
+    template: `%s | ${site.name}`,
+    default: site.name,
   },
-  description:
-    "Comprehensive database for X-ray spectroscopy data collected by the WSU Collins Lab",
+  description: mission.seoDescription,
   icons: [{ rel: "icon", url: "https://repo.wsu.edu/favicon/icon.svg" }],
   openGraph: {
     type: "website",
-    url: "https://xrayatlas.wsu.edu",
-    title: "Xray Atlas | WSU Collins Research Group",
-    description:
-      "Comprehensive database for X-ray spectroscopy data collected by the WSU Collins Lab",
-    siteName: "Xray Atlas",
+    url: site.url,
+    title: mission.ogTitle,
+    description: mission.seoDescription,
+    siteName: site.name,
     images: [
       {
         url: "https://wpcdn.web.wsu.edu/wp-labs/uploads/sites/945/2017/11/Scattxrayering-Rendering.jpg",
         width: 1200,
         height: 630,
-        alt: "Xray Atlas Preview Image",
+        alt: "X-ray Atlas — open NEXAFS spectroscopy database",
       },
     ],
     locale: "en_US",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Xray Atlas | WSU Collins Research Group",
-    description:
-      "Comprehensive database for X-ray spectroscopy data collected by the WSU Collins Lab",
+    title: mission.ogTitle,
+    description: mission.seoDescription,
     images: ["https://wpcdn.web.wsu.edu/wp-labs/uploads/sites/945/2017/11/Scattxrayering-Rendering.jpg"],
   },
-  applicationName: "Xray Atlas",
+  applicationName: site.applicationName,
   keywords: [
-    // Research Group Keywords
+    // Hosting lab
     "WSU",
     "Washington State University",
+    "WSU Carbon Lab",
     "WSU Physics",
     "Brian Collins",
-    "WSU Collins Research Group",
-    // Open Data Keywords
+    "Collins Research Group",
+    // Open / FAIR data
     "Open Data",
+    "FAIR Data",
     "Data Repository",
     "Data Archive",
-    // Research Concept Keywords
+    "Open Science",
+    // Research domains
     "Materials science",
     "Materials physics",
     "Atomic Molecular and Optical Physics",
     "Soft Matter Physics",
-    "Material Engineering",
+    "Materials Engineering",
     "Advanced Functional Materials",
-    // Spectroscopy Keywords
-    "X-ray science",
-    "X-ray spectroscopy",
+    "Organic Semiconductors",
+    "Polymer Physics",
+    // Spectroscopy — primary
     "NEXAFS",
+    "Near-Edge X-ray Absorption Fine Structure",
     "X-ray absorption fine structure",
     "X-ray absorption spectroscopy",
     "EXAFS",
     "XAS",
-    "X-ray near edge absorption fine structure",
-    // Other X-ray Science Keywords
+    "X-ray spectroscopy",
+    "X-ray science",
+    // Spectroscopy — related techniques
     "X-ray diffraction",
     "X-ray scattering",
-    "X-ray crystallography",
-    "X-ray imaging",
-    "X-ray computed tomography",
-    "X-ray microtomography",
-    "Resonant Scattering",
-    "Polarized Scattering",
+    "Resonant Soft X-ray Scattering",
     "RSoXS",
     "PRSoXS",
     "RSoXR",
     "PRSoXR",
-    // Instrument / Facility Keywords
+    "X-ray crystallography",
+    "X-ray imaging",
+    // Facilities
     "Advanced Light Source",
     "ALS",
     "National Synchrotron Light Source",
@@ -95,9 +95,18 @@ export const siteMetadata: Metadata = {
     "Lawrence Berkeley National Laboratory",
     "LBNL",
     "Berkeley Lab",
+    // Discovery and attribution
+    "spectroscopy provenance",
+    "citable spectra",
+    "DOI data citation",
+    "synchrotron data",
+    "open spectroscopy database",
   ],
   authors: [
-    { name: "WSU Collins Research Group", url: "https://labs.wsu.edu/carbon/" },
+    {
+      name: attribution.lab,
+      url: attribution.labUrl,
+    },
   ],
   robots: {
     index: true,

--- a/src/app/opensearch.xml/route.ts
+++ b/src/app/opensearch.xml/route.ts
@@ -1,3 +1,5 @@
+import { site } from "~/app/brand";
+
 function xmlEscape(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -8,8 +10,8 @@ function xmlEscape(value: string): string {
 }
 
 function buildOpenSearchXml(origin: string): string {
-  const shortName = "Xray Atlas";
-  const description = "Search molecules in Xray Atlas by name, synonym, and identifiers.";
+  const shortName = site.applicationName;
+  const description = `Search molecules in ${site.name} by name, synonym, and identifiers.`;
   const searchTemplate = `${origin}/api/molecules/search?q={searchTerms}`;
   const selfTemplate = `${origin}/opensearch.xml`;
   const iconUrl = "https://repo.wsu.edu/favicon/icon.svg";
@@ -27,7 +29,7 @@ function buildOpenSearchXml(origin: string): string {
 }
 
 /**
- * Serves an OpenSearch descriptor so browsers can install Xray Atlas molecule search.
+ * Serves an OpenSearch descriptor so browsers can install X-ray Atlas molecule search.
  *
  * The descriptor points search requests to `/api/molecules/search?q={searchTerms}`,
  * which supports unified matching and redirect behavior for molecule discovery.

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { site } from "~/app/brand";
 
 export const metadata: Metadata = {
   title: "Privacy and Data Use",
   description:
-    "Privacy, account data handling, and citation guidance for open datasets on X-ray Atlas.",
+    `Privacy, account data handling, and citation guidance for open datasets on ${site.name}.`,
 };
 
 /**
@@ -22,7 +23,7 @@ export default function PrivacyPage() {
             Privacy and Data Use
           </h1>
           <p className="text-muted text-lg">
-            X-ray Atlas publishes open spectroscopy metadata and spectra for
+            {site.name} publishes open spectroscopy metadata and spectra for
             research use. This page explains what information is public, what is
             used for accounts and platform operations, and how to cite datasets
             to preserve contributor attribution.
@@ -40,7 +41,7 @@ export default function PrivacyPage() {
           </p>
           <p className="text-muted">
             If your workflow requires non-public data, do not upload it to
-            X-ray Atlas unless and until your team is ready for public release.
+            {site.name} unless and until your team is ready for public release.
           </p>
           <p className="text-muted">
             If you need a non-public workflow, contact the core maintainers to
@@ -83,20 +84,20 @@ export default function PrivacyPage() {
             . Citation is required when reusing hosted datasets.
           </p>
           <p className="text-muted">
-            Each dataset has a minted DOI. When using X-ray Atlas data, cite:
+            Each dataset has a minted DOI. When using {site.name} data, cite:
           </p>
           <div className="border-border bg-surface space-y-3 rounded-lg border p-4">
             <div>
               <h3 className="text-foreground font-semibold">Individual dataset</h3>
               <p className="text-muted font-mono text-sm">
                 [Dataset Name] [DOI]. Adapted from [Original Publication].
-                Hosted by X-Ray Atlas.
+                Hosted by {site.name}.
               </p>
             </div>
             <div>
               <h3 className="text-foreground font-semibold">Entire collection</h3>
               <p className="text-muted font-mono text-sm">
-                X-Ray Atlas [Collection DOI]. Accessed [Date].
+                {site.name} [Collection DOI]. Accessed [Date].
               </p>
             </div>
           </div>

--- a/src/app/wiki/contributions/page.tsx
+++ b/src/app/wiki/contributions/page.tsx
@@ -4,11 +4,12 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
+import { site } from "~/app/brand";
 
 export const metadata: Metadata = {
   title: "Database Contributions",
   description:
-    "How to contribute NEXAFS datasets to Xray Atlas with metadata quality, reproducibility, and citation-ready attribution.",
+    `How to contribute NEXAFS datasets to ${site.name} with metadata quality, reproducibility, and citation-ready attribution.`,
 };
 
 export default function ContributionsPage() {
@@ -18,7 +19,7 @@ export default function ContributionsPage() {
         Database contributions
       </h1>
       <p className="text-muted">
-        Contributions keep Xray Atlas scientifically useful. The goal is to pair
+        Contributions keep {site.name} scientifically useful. The goal is to pair
         each spectrum with enough context for interpretation, comparison, and
         citation.
       </p>

--- a/src/app/wiki/data-representation/page.tsx
+++ b/src/app/wiki/data-representation/page.tsx
@@ -5,11 +5,12 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
+import { site } from "~/app/brand";
 
 export const metadata: Metadata = {
   title: "Data Representation and Structure",
   description:
-    "How Xray Atlas represents molecules, samples, experiments, and spectroscopy traces for robust querying and scientific reuse.",
+    `How ${site.name} represents molecules, samples, experiments, and spectroscopy traces for robust querying and scientific reuse.`,
 };
 
 export default function DataRepresentationPage() {
@@ -19,7 +20,7 @@ export default function DataRepresentationPage() {
         Data representation and structure
       </h1>
       <p className="text-muted">
-        Xray Atlas stores spectroscopy records so users can query both
+        {site.name} stores spectroscopy records so users can query both
         scientific content and experimental provenance. Dataset pages combine
         molecules, spectrum traces, and metadata in one navigable model.
       </p>

--- a/src/app/wiki/home/page.tsx
+++ b/src/app/wiki/home/page.tsx
@@ -1,10 +1,11 @@
 /**
- * Wiki home route: canonical NEXAFS terminology and interpretation primer for Xray Atlas.
+ * Wiki home route: canonical NEXAFS terminology and interpretation primer for X-ray Atlas.
  */
 
 import type { ComponentType } from "react";
 import type { Metadata } from "next";
 import { NexafsCoreAbsorptionSchematic } from "~/components/nexafs/nexafs-core-absorption-schematic";
+import { site } from "~/app/brand";
 import {
   BeakerIcon,
   BookOpenIcon,
@@ -15,7 +16,7 @@ import {
 export const metadata: Metadata = {
   title: "Wiki home",
   description:
-    "NEXAFS reference for terminology, scientific targets, and interpretation context used across the Xray Atlas spectroscopy database.",
+    `NEXAFS reference for terminology, scientific targets, and interpretation context used across the ${site.name} spectroscopy database.`,
 };
 
 const terminologyCards = [
@@ -23,7 +24,7 @@ const terminologyCards = [
     short: "NEXAFS",
     full: "Near-Edge X-ray Absorption Fine Structure",
     body:
-      "Preferred term on Xray Atlas. Emphasizes fine structure in the near-edge region arising from local bonding and electronic structure.",
+      `Preferred term on ${site.name}. Emphasizes fine structure in the near-edge region arising from local bonding and electronic structure.`,
   },
   {
     short: "XANES",
@@ -99,7 +100,7 @@ export default function NexafsWikiPage() {
                 element-specific method that probes transitions from core electronic
                 states into unoccupied bound and quasi-bound states near an
                 absorption edge (for example carbon, nitrogen, or sulfur K-edges).
-                This page anchors terminology for Xray Atlas so spectra and
+                This page anchors terminology for {site.name} so spectra and
                 metadata are read consistently across molecules, instruments, and
                 facilities.
               </p>
@@ -121,7 +122,7 @@ export default function NexafsWikiPage() {
           />
           <p className="text-muted mb-6 max-w-none">
             X-ray spectroscopy communities use several labels for closely related
-            near-edge measurements. Below is how Xray Atlas uses each term when
+            near-edge measurements. Below is how {site.name} uses each term when
             indexing and describing datasets.
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -167,7 +168,7 @@ export default function NexafsWikiPage() {
         <section className="border-border bg-surface rounded-2xl border p-6 sm:p-8">
           <SectionHeader
             icon={CubeTransparentIcon}
-            title="Representations stored in Xray Atlas"
+            title={`Representations stored in ${site.name}`}
             id="representations-stored"
           />
           <p className="text-muted mb-6 max-w-none">
@@ -193,7 +194,7 @@ export default function NexafsWikiPage() {
               <strong className="text-foreground">Optical density (OD)</strong>
               <p className="text-muted mt-2 text-sm leading-relaxed">
                 Proportional to mass absorption up to experimental factors. In
-                Xray Atlas, OD naming denotes traces scaled so the pre-edge trends
+                {site.name}, OD naming denotes traces scaled so the pre-edge trends
                 toward zero and the post-edge trends toward one after the chosen
                 normalization workflow.
               </p>

--- a/src/app/wiki/platform-features/page.tsx
+++ b/src/app/wiki/platform-features/page.tsx
@@ -4,11 +4,12 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
+import { site } from "~/app/brand";
 
 export const metadata: Metadata = {
   title: "Platform Features",
   description:
-    "Core Xray Atlas features for searching, filtering, visualizing, and contributing NEXAFS and X-ray spectroscopy datasets.",
+    `Core ${site.name} features for searching, filtering, visualizing, and contributing NEXAFS and X-ray spectroscopy datasets.`,
 };
 
 const featureItems = [
@@ -43,7 +44,7 @@ export default function PlatformFeaturesPage() {
     <div className="w-full min-w-0 space-y-6">
       <h1 className="text-foreground text-4xl font-bold">Platform features</h1>
       <p className="text-muted">
-        Xray Atlas is built for day-to-day spectroscopy workflows: finding
+        {site.name} is built for day-to-day spectroscopy workflows: finding
         relevant NEXAFS data quickly, validating context, and contributing new
         measurements in a reusable format.
       </p>

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { WSULogoIcon } from "../icons";
 import GitHubStarsLink from "./github-stars-link";
 import { trpc } from "~/trpc/client";
+import { attribution, mission, site } from "~/app/brand";
 
 export function Footer() {
   const { data: collaboratorsData, isLoading: isLoadingCollaborators } =
@@ -15,7 +16,7 @@ export function Footer() {
           <div className="flex items-center gap-2">
             <WSULogoIcon className="h-6 w-6" />
             <span className="font-sans text-xl font-semibold text-foreground">
-              X-ray Atlas
+              {site.name}
             </span>
           </div>
           <div className="flex items-center gap-3 text-2xl">
@@ -25,10 +26,10 @@ export function Footer() {
         <div className="grid grid-cols-1 gap-8 md:grid-cols-8">
           <div className="col-span-3 space-y-4">
             <h3 className="font-sans text-lg text-foreground">
-              X-ray Atlas
+              {site.name}
             </h3>
             <p className="text-muted flex-wrap text-sm">
-              Advancing material research through collaborative data.
+              {mission.heroShort}
             </p>
             {isLoadingCollaborators ? (
               <div className="text-muted text-sm">Loading...</div>
@@ -38,7 +39,7 @@ export function Footer() {
                   collaboratorsData.hosts.length > 0 && (
                     <div>
                       <h4 className="mb-2 text-sm font-semibold text-foreground">
-                        Hosted By
+                        Hosted by {attribution.lab}
                       </h4>
                       <div className="space-y-1">
                         {collaboratorsData.hosts.map((host) => (
@@ -133,7 +134,7 @@ export function Footer() {
         </div>
         <div className="border-border mt-8 flex flex-col justify-between border-t pt-4 md:flex-row">
           <div className="text-muted text-center text-sm md:text-left">
-            © {new Date().getFullYear()} X-ray Atlas. All rights reserved.
+            © {new Date().getFullYear()} {site.name}. All rights reserved.
           </div>
           <div className="mt-4 flex justify-center gap-4 text-sm md:mt-0 md:justify-end">
             <Link

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -76,7 +76,7 @@ function AboutDropdown() {
               className="text-foreground hover:bg-default flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors"
             >
               <InformationCircleIcon className="text-accent h-4 w-4" />
-              <span>About {site.name}</span>
+              <span>About</span>
             </button>
             <button
               type="button"

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -18,6 +18,7 @@ import {
   InformationCircleIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
+import { site } from "~/app/brand";
 
 function AboutDropdown() {
   const [isOpen, setIsOpen] = useState(false);
@@ -75,7 +76,7 @@ function AboutDropdown() {
               className="text-foreground hover:bg-default flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors"
             >
               <InformationCircleIcon className="text-accent h-4 w-4" />
-              <span>About X-ray Atlas</span>
+              <span>About {site.name}</span>
             </button>
             <button
               type="button"
@@ -287,7 +288,7 @@ export default function Header() {
             >
               <WSULogoIcon className="block h-10 w-10 justify-start align-middle" />
               <span className="align-middle font-sans text-3xl leading-none font-bold">
-                X-ray Atlas
+                {site.name}
               </span>
             </Link>
           </div>

--- a/src/lib/wiki-doc-nav.ts
+++ b/src/lib/wiki-doc-nav.ts
@@ -33,7 +33,7 @@ export const wikiDocTopics: readonly WikiDocTopic[] = [
     sections: [
       { id: "terminology-heading", label: "The zoo of names for the same idea" },
       { id: "nexafs-probes", label: "What NEXAFS probes" },
-      { id: "representations-stored", label: "Representations stored in Xray Atlas" },
+      { id: "representations-stored", label: "Representations stored in X-ray Atlas" },
       { id: "coordinates-and-units", label: "Coordinates and units" },
     ],
   },


### PR DESCRIPTION
## Summary

Align branding and mission copy to the canonical `src/app/brand.ts` source, and improve the About page by moving FAIR alignment directly after the mission statement with a clearer 2x2 principle grid.

## Changes

- Add canonical branding source module at `src/app/brand.ts` and wire it into metadata, home, about, footer, header, privacy, wiki pages, and OpenSearch labels.
- Update About page mission presentation and move FAIR content above "What the database includes" with principle cards and icons.
- Add AGENTS guidance declaring `src/app/brand.ts` as branding source-of-truth and usage rules.

## Test Plan

- [x] Tested locally (`bun run lint`)
- [ ] Tested OAuth flow (if auth changes)
- [ ] Tested on mobile (if UI changes)

## AI Role (required)

- [ ] Level 1: Mostly suggestions, tab completion, and minimal code generation
- [x] Level 2: Extensive code generation, but heavily managed; business and scientific logic was dictated by the contributor
- [ ] Level 3: Fully vibe coded; PRs using this level will likely be thrown away, but may contain nuggets a maintainer chooses to review

Validated correctness with `bun run lint`, `bun run typecheck`, and focused manual inspection of affected copy/layout surfaces.

## Screenshots (if UI changes)

Before | After
--- | ---
img | img