### PR TITLE
chore(seo): improve entity metadata, canonical SEO, and internal linking

### DIFF
--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "X-ray spectroscopy database",
+  description:
+    "Open X-ray Atlas for NEXAFS and X-ray spectroscopy datasets with molecule search, spectrum browsing, and reproducible metadata.",
+  alternates: {
+    canonical: "/",
+  },
+};
+
+export default function HomeLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,6 +6,10 @@ import { db } from "~/server/db";
 
 export const metadata = {
   title: "Administration",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
 export default async function AdminLayout({

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -63,7 +63,7 @@ function RoleFaviconUrlPreview({
       <img
         key={t}
         src={t}
-        alt=""
+        alt="Role favicon preview"
         className="border-border size-10 rounded-lg border object-cover"
         onError={(e) => {
           e.currentTarget.style.display = "none";
@@ -158,7 +158,7 @@ function AdminRoleChipContent({
       {faviconUrl ? (
         <img
           src={faviconUrl}
-          alt=""
+          alt={`${displayName} role favicon`}
           className="size-3 shrink-0 rounded-sm object-cover"
           onError={(e) => {
             e.currentTarget.style.display = "none";

--- a/src/app/api/molecules/search/route.ts
+++ b/src/app/api/molecules/search/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { db } from "~/server/db";
+import { slugifyMoleculeSynonym } from "~/lib/molecule-slug";
 
 const SEARCH_PARAM_KEYS = ["q", "query", "search", "s"] as const;
 const SEARCH_TERM_SCHEMA = z.string().trim().min(1).max(256);
@@ -97,8 +98,16 @@ function buildBrowseUrl(origin: string, searchTerm: string): URL {
   return url;
 }
 
-function buildMoleculeUrl(origin: string, moleculeId: string): URL {
-  return new URL(`/molecules/${moleculeId}`, origin);
+function canonicalMoleculeSlug(molecule: SearchableMolecule): string {
+  const synonym = molecule.moleculesynonyms[0]?.synonym?.trim();
+  if (synonym) {
+    return slugifyMoleculeSynonym(synonym);
+  }
+  return slugifyMoleculeSynonym(molecule.iupacname);
+}
+
+function buildMoleculeUrl(origin: string, molecule: SearchableMolecule): URL {
+  return new URL(`/molecules/${canonicalMoleculeSlug(molecule)}`, origin);
 }
 
 /**
@@ -168,11 +177,17 @@ export async function GET(request: Request): Promise<NextResponse> {
   const ranked = molecules
     .map((molecule) => rankMolecule(molecule, normalizedQuery))
     .sort((a, b) => b.score - a.score);
+  const moleculeById = new Map(molecules.map((molecule) => [molecule.id, molecule]));
 
   const exactMatches = ranked.filter((entry) => entry.hasExactMatch);
 
   if (exactMatches.length === 1) {
-    const destination = buildMoleculeUrl(requestUrl.origin, exactMatches[0]!.moleculeId);
+    const bestMatch = moleculeById.get(exactMatches[0]!.moleculeId);
+    if (!bestMatch) {
+      const browseUrl = buildBrowseUrl(requestUrl.origin, searchTerm);
+      return NextResponse.redirect(browseUrl, { status: 307 });
+    }
+    const destination = buildMoleculeUrl(requestUrl.origin, bestMatch);
     return NextResponse.redirect(destination, { status: 307 });
   }
 
@@ -182,14 +197,24 @@ export async function GET(request: Request): Promise<NextResponse> {
   }
 
   if (ranked.length === 1) {
-    const destination = buildMoleculeUrl(requestUrl.origin, ranked[0]!.moleculeId);
+    const bestMatch = moleculeById.get(ranked[0]!.moleculeId);
+    if (!bestMatch) {
+      const browseUrl = buildBrowseUrl(requestUrl.origin, searchTerm);
+      return NextResponse.redirect(browseUrl, { status: 307 });
+    }
+    const destination = buildMoleculeUrl(requestUrl.origin, bestMatch);
     return NextResponse.redirect(destination, { status: 307 });
   }
 
   const best = ranked[0]!;
   const secondBest = ranked[1]!;
   if (best.score - secondBest.score >= 35) {
-    const destination = buildMoleculeUrl(requestUrl.origin, best.moleculeId);
+    const bestMatch = moleculeById.get(best.moleculeId);
+    if (!bestMatch) {
+      const browseUrl = buildBrowseUrl(requestUrl.origin, searchTerm);
+      return NextResponse.redirect(browseUrl, { status: 307 });
+    }
+    const destination = buildMoleculeUrl(requestUrl.origin, bestMatch);
     return NextResponse.redirect(destination, { status: 307 });
   }
 

--- a/src/app/browse/facilities/layout.tsx
+++ b/src/app/browse/facilities/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Browse facilities",
+  description:
+    "Browse synchrotron and lab facilities in X-ray Atlas with registered instruments and linked spectroscopy datasets.",
+  alternates: {
+    canonical: "/browse/facilities",
+  },
+};
+
+export default function BrowseFacilitiesLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/browse/molecules/layout.tsx
+++ b/src/app/browse/molecules/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Browse molecules",
+  description:
+    "Browse molecules in X-ray Atlas with searchable identifiers, dataset counts, and linked NEXAFS experiment context.",
+  alternates: {
+    canonical: "/browse/molecules",
+  },
+};
+
+export default function BrowseMoleculesLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/browse/nexafs/layout.tsx
+++ b/src/app/browse/nexafs/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Browse NEXAFS datasets",
+  description:
+    "Browse NEXAFS experiments by molecule, edge, facility, instrument, and geometry metadata in X-ray Atlas.",
+  alternates: {
+    canonical: "/browse/nexafs",
+  },
+};
+
+export default function BrowseNexafsLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -1,15 +1,5 @@
-"use client";
-
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { redirect } from "next/navigation";
 
 export default function BrowsePage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    // Redirect to molecules browse page by default
-    router.replace("/browse/molecules");
-  }, [router]);
-
-  return null;
+  redirect("/browse/molecules");
 }

--- a/src/app/contribute/facility/layout.tsx
+++ b/src/app/contribute/facility/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contribute facility",
+  description:
+    "Register a facility and instruments for spectroscopy submissions in X-ray Atlas contribution workflows.",
+  alternates: {
+    canonical: "/contribute/facility",
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function ContributeFacilityLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/contribute/layout.tsx
+++ b/src/app/contribute/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contribute spectroscopy data",
+  description:
+    "Contribute molecules, facilities, and NEXAFS datasets to X-ray Atlas with structured metadata and attribution-ready records.",
+  alternates: {
+    canonical: "/contribute",
+  },
+};
+
+export default function ContributeLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/contribute/molecule/layout.tsx
+++ b/src/app/contribute/molecule/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contribute molecule",
+  description:
+    "Submit molecule records with identifiers and metadata to expand search and linking across X-ray Atlas datasets.",
+  alternates: {
+    canonical: "/contribute/molecule",
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function ContributeMoleculeLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/contribute/nexafs/layout.tsx
+++ b/src/app/contribute/nexafs/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contribute NEXAFS dataset",
+  description:
+    "Upload NEXAFS experiments with instrument, edge, and geometry metadata to X-ray Atlas.",
+  alternates: {
+    canonical: "/contribute/nexafs",
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function ContributeNexafsLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/facilities/[id]/layout.tsx
+++ b/src/app/facilities/[id]/layout.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import { db } from "~/server/db";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+
+  const facility = await db.facilities.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      city: true,
+      country: true,
+      _count: { select: { instruments: true } },
+    },
+  });
+
+  if (!facility) {
+    return {
+      title: "Facility not found",
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const location = [facility.city, facility.country].filter(Boolean).join(", ");
+  const locationPhrase = location ? ` in ${location}` : "";
+  const instrumentCount = facility._count.instruments;
+
+  return {
+    title: `${facility.name} facility`,
+    description: `${facility.name}${locationPhrase} with ${instrumentCount} registered instrument${instrumentCount === 1 ? "" : "s"} in X-ray Atlas.`,
+    alternates: {
+      canonical: `/facilities/${facility.id}`,
+    },
+    openGraph: {
+      title: `${facility.name} | X-ray Atlas`,
+      description: `${facility.name}${locationPhrase} with ${instrumentCount} registered instrument${instrumentCount === 1 ? "" : "s"}.`,
+      url: `/facilities/${facility.id}`,
+    },
+  };
+}
+
+export default function FacilityDetailLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/facilities/[id]/layout.tsx
+++ b/src/app/facilities/[id]/layout.tsx
@@ -1,5 +1,21 @@
 import type { Metadata } from "next";
 import { db } from "~/server/db";
+import type { FacilityType } from "~/prisma/browser";
+
+function facilityTypeLabel(t: FacilityType): string {
+  switch (t) {
+    case "SYNCHROTRON":
+      return "Synchrotron";
+    case "FREE_ELECTRON_LASER":
+      return "Free Electron Laser";
+    case "LAB_SOURCE":
+      return "Lab Source";
+    default: {
+      const _exhaustive: never = t;
+      return _exhaustive;
+    }
+  }
+}
 
 export async function generateMetadata({
   params,
@@ -15,6 +31,12 @@ export async function generateMetadata({
       name: true,
       city: true,
       country: true,
+      facilitytype: true,
+      instruments: {
+        select: { name: true },
+        orderBy: { name: "asc" },
+        take: 2,
+      },
       _count: { select: { instruments: true } },
     },
   });
@@ -29,17 +51,30 @@ export async function generateMetadata({
   const location = [facility.city, facility.country].filter(Boolean).join(", ");
   const locationPhrase = location ? ` in ${location}` : "";
   const instrumentCount = facility._count.instruments;
+  const typeShort = facilityTypeLabel(facility.facilitytype);
+  const instrumentNames = facility.instruments.map((i) => i.name.trim()).filter(Boolean);
+  const instrumentPhrase =
+    instrumentNames.length > 0
+      ? ` Notable instruments: ${instrumentNames.join(" and ")}.`
+      : "";
+
+  const description = `${facility.name} (${typeShort} facility)${locationPhrase}. ${instrumentCount} registered instrument${instrumentCount === 1 ? "" : "s"} in X-ray Atlas.${instrumentPhrase}`;
 
   return {
     title: `${facility.name} facility`,
-    description: `${facility.name}${locationPhrase} with ${instrumentCount} registered instrument${instrumentCount === 1 ? "" : "s"} in X-ray Atlas.`,
+    description,
     alternates: {
       canonical: `/facilities/${facility.id}`,
     },
     openGraph: {
       title: `${facility.name} | X-ray Atlas`,
-      description: `${facility.name}${locationPhrase} with ${instrumentCount} registered instrument${instrumentCount === 1 ? "" : "s"}.`,
+      description,
       url: `/facilities/${facility.id}`,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${facility.name} | X-ray Atlas`,
+      description,
     },
   };
 }

--- a/src/app/facilities/[id]/page.tsx
+++ b/src/app/facilities/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { trpc } from "~/trpc/client";
 import { ErrorState } from "@/components/feedback/error-state";
@@ -122,6 +123,61 @@ export default function FacilityDetailPage({
             </div>
           </div>
         </div>
+
+        <nav
+          aria-label="Explore related catalogs"
+          className="border-border mt-8 border-t pt-6"
+        >
+          <p className="text-muted mb-3 text-xs font-medium tracking-wide uppercase">
+            Explore
+          </p>
+          <ul className="text-muted flex flex-wrap gap-x-5 gap-y-2 text-sm">
+            {facility.instruments.slice(0, 2).map((instrument) => (
+              <li key={instrument.id}>
+                <Link
+                  href={`/browse/nexafs?instrument=${encodeURIComponent(instrument.id)}`}
+                  className="text-accent hover:text-accent-dark font-medium underline-offset-2 hover:underline"
+                >
+                  NEXAFS: {instrument.name}
+                </Link>
+              </li>
+            ))}
+            {facility.instruments.length === 0 ? (
+              <li>
+                <Link
+                  href="/browse/nexafs"
+                  className="text-accent hover:text-accent-dark font-medium underline-offset-2 hover:underline"
+                >
+                  Browse NEXAFS experiments
+                </Link>
+              </li>
+            ) : null}
+            <li>
+              <Link
+                href="/browse/facilities"
+                className="text-accent hover:text-accent-dark font-medium underline-offset-2 hover:underline"
+              >
+                All facilities
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/wiki/home"
+                className="text-accent hover:text-accent-dark font-medium underline-offset-2 hover:underline"
+              >
+                NEXAFS wiki
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/wiki/platform-features"
+                className="text-accent hover:text-accent-dark font-medium underline-offset-2 hover:underline"
+              >
+                Platform features
+              </Link>
+            </li>
+          </ul>
+        </nav>
 
         <Card className="border-border bg-surface-1 overflow-hidden border shadow-sm">
           <Card.Header className="border-border flex flex-col gap-3 border-b px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -3,9 +3,6 @@ import { attribution, mission, site } from "~/app/brand";
 
 export const siteMetadata: Metadata = {
   metadataBase: new URL(site.url),
-  alternates: {
-    canonical: "/",
-  },
   title: {
     template: `%s | ${site.name}`,
     default: site.name,

--- a/src/app/molecules/[id]/layout.tsx
+++ b/src/app/molecules/[id]/layout.tsx
@@ -1,4 +1,5 @@
-import { notFound } from "next/navigation";
+import { type Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
 import { api } from "~/trpc/server";
 import { MoleculeDetailLayoutClient } from "@/components/browse/molecule-detail-layout-client";
 import Link from "next/link";
@@ -12,6 +13,73 @@ function isSlugCollision(
   candidates: Array<{ id: string; name: string; iupacName: string; slug: string }>;
 } {
   return typeof v === "object" && v != null && "kind" in v;
+}
+
+async function resolveMoleculeByRouteId(routeId: string) {
+  const isUuid =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      routeId,
+    );
+
+  if (isUuid) {
+    return await api.molecules.getById({ id: routeId });
+  }
+
+  const normalizedSlug = slugifyMoleculeSynonym(routeId);
+  return await api.molecules.getBySlug({ slug: normalizedSlug });
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id: routeId } = await params;
+
+  try {
+    const resolved = await resolveMoleculeByRouteId(routeId);
+    if (!resolved || isSlugCollision(resolved)) {
+      return {
+        title: "Molecule not found",
+        robots: { index: false, follow: false },
+      };
+    }
+
+    const canonicalSlug = canonicalMoleculeSlugFromView(resolved);
+    const moleculeName = resolved.name.trim();
+    const datasetCount = resolved.experimentCount ?? 0;
+
+    return {
+      title: `${moleculeName} NEXAFS datasets`,
+      description:
+        datasetCount > 0
+          ? `${moleculeName} in X-ray Atlas with ${datasetCount} NEXAFS dataset${datasetCount === 1 ? "" : "s"}, molecular identifiers, and linked spectroscopy metadata.`
+          : `${moleculeName} in X-ray Atlas with molecular identifiers and spectroscopy metadata.`,
+      alternates: {
+        canonical: `/molecules/${canonicalSlug}`,
+      },
+      openGraph: {
+        title: `${moleculeName} | X-ray Atlas`,
+        description:
+          datasetCount > 0
+            ? `Explore ${datasetCount} NEXAFS dataset${datasetCount === 1 ? "" : "s"} for ${moleculeName}.`
+            : `Explore molecular data and linked spectroscopy context for ${moleculeName}.`,
+        url: `/molecules/${canonicalSlug}`,
+      },
+      twitter: {
+        title: `${moleculeName} | X-ray Atlas`,
+        description:
+          datasetCount > 0
+            ? `Explore ${datasetCount} NEXAFS dataset${datasetCount === 1 ? "" : "s"} for ${moleculeName}.`
+            : `Explore molecular data and linked spectroscopy context for ${moleculeName}.`,
+      },
+    };
+  } catch {
+    return {
+      title: "Molecule not found",
+      robots: { index: false, follow: false },
+    };
+  }
 }
 
 export default async function MoleculeDetailLayout({
@@ -29,19 +97,10 @@ export default async function MoleculeDetailLayout({
 
   let molecule: Awaited<ReturnType<typeof api.molecules.getById>> | null = null;
 
-  if (isUuid) {
-    try {
-      molecule = await api.molecules.getById({ id: routeId });
-    } catch (err: unknown) {
-      const code = (err as { data?: { code?: string } })?.data?.code;
-      if (code === "NOT_FOUND") notFound();
-      throw err;
-    }
-  } else {
-    const normalizedSlug = slugifyMoleculeSynonym(routeId);
-    const result = await api.molecules.getBySlug({ slug: normalizedSlug });
-    if (isSlugCollision(result)) {
-      const collision = result;
+  try {
+    const resolved = await resolveMoleculeByRouteId(routeId);
+    if (isSlugCollision(resolved)) {
+      const collision = resolved;
       return (
         <div className="py-8">
           <div className="mx-auto max-w-3xl space-y-6">
@@ -86,15 +145,18 @@ export default async function MoleculeDetailLayout({
         </div>
       );
     }
-    molecule = result;
+    molecule = resolved;
+  } catch (err: unknown) {
+    const code = (err as { data?: { code?: string } })?.data?.code;
+    if (code === "NOT_FOUND") notFound();
+    throw err;
   }
 
   if (!molecule) notFound();
 
   const canonicalSlug = canonicalMoleculeSlugFromView(molecule);
-  if (!isUuid && routeId !== canonicalSlug) {
-    // Intentionally not redirecting yet; we keep behavior stable until we decide
-    // whether canonical redirects are desired in this route.
+  if (isUuid || routeId !== canonicalSlug) {
+    redirect(`/molecules/${canonicalSlug}`);
   }
 
   return (

--- a/src/app/molecules/[id]/layout.tsx
+++ b/src/app/molecules/[id]/layout.tsx
@@ -4,6 +4,11 @@ import { api } from "~/trpc/server";
 import { MoleculeDetailLayoutClient } from "@/components/browse/molecule-detail-layout-client";
 import Link from "next/link";
 import { canonicalMoleculeSlugFromView, slugifyMoleculeSynonym } from "~/lib/molecule-slug";
+import {
+  buildMoleculeChemicalSubstanceJsonLd,
+  buildMoleculeDetailSeoText,
+  serializeMoleculeJsonLdScriptContent,
+} from "~/lib/molecule-schema-org";
 
 function isSlugCollision(
   v: Awaited<ReturnType<typeof api.molecules.getBySlug>>,
@@ -46,32 +51,24 @@ export async function generateMetadata({
     }
 
     const canonicalSlug = canonicalMoleculeSlugFromView(resolved);
+    const { title, description } = buildMoleculeDetailSeoText(resolved);
     const moleculeName = resolved.name.trim();
-    const datasetCount = resolved.experimentCount ?? 0;
 
     return {
-      title: `${moleculeName} NEXAFS datasets`,
-      description:
-        datasetCount > 0
-          ? `${moleculeName} in X-ray Atlas with ${datasetCount} NEXAFS dataset${datasetCount === 1 ? "" : "s"}, molecular identifiers, and linked spectroscopy metadata.`
-          : `${moleculeName} in X-ray Atlas with molecular identifiers and spectroscopy metadata.`,
+      title,
+      description,
       alternates: {
         canonical: `/molecules/${canonicalSlug}`,
       },
       openGraph: {
         title: `${moleculeName} | X-ray Atlas`,
-        description:
-          datasetCount > 0
-            ? `Explore ${datasetCount} NEXAFS dataset${datasetCount === 1 ? "" : "s"} for ${moleculeName}.`
-            : `Explore molecular data and linked spectroscopy context for ${moleculeName}.`,
+        description,
         url: `/molecules/${canonicalSlug}`,
       },
       twitter: {
+        card: "summary_large_image",
         title: `${moleculeName} | X-ray Atlas`,
-        description:
-          datasetCount > 0
-            ? `Explore ${datasetCount} NEXAFS dataset${datasetCount === 1 ? "" : "s"} for ${moleculeName}.`
-            : `Explore molecular data and linked spectroscopy context for ${moleculeName}.`,
+        description,
       },
     };
   } catch {
@@ -159,9 +156,19 @@ export default async function MoleculeDetailLayout({
     redirect(`/molecules/${canonicalSlug}`);
   }
 
+  const moleculeJsonLd = serializeMoleculeJsonLdScriptContent(
+    buildMoleculeChemicalSubstanceJsonLd(molecule, canonicalSlug),
+  );
+
   return (
-    <MoleculeDetailLayoutClient molecule={molecule} moleculeId={molecule.id}>
-      {children}
-    </MoleculeDetailLayoutClient>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: moleculeJsonLd }}
+      />
+      <MoleculeDetailLayoutClient molecule={molecule} moleculeId={molecule.id}>
+        {children}
+      </MoleculeDetailLayoutClient>
+    </>
   );
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -2,7 +2,13 @@ import { type MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [{ userAgent: "*", allow: "/" }],
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/admin/", "/sandbox/", "/sign-in/", "/contribute/"],
+      },
+    ],
     sitemap: "https://xrayatlas.wsu.edu/sitemap.xml",
   };
 }

--- a/src/app/sandbox/layout.tsx
+++ b/src/app/sandbox/layout.tsx
@@ -4,6 +4,10 @@ import { auth } from "~/server/auth";
 
 export const metadata = {
   title: "Sandbox",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
 /**

--- a/src/app/sign-in/layout.tsx
+++ b/src/app/sign-in/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign in",
+  description: "Sign in to access contribution and account-management features in X-ray Atlas.",
+  alternates: {
+    canonical: "/sign-in",
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function SignInLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,74 +1,104 @@
 import { type MetadataRoute } from "next";
+import { slugifyMoleculeSynonym } from "~/lib/molecule-slug";
+import { db } from "~/server/db";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
+  const baseUrl = "https://xrayatlas.wsu.edu";
+
+  const [molecules, facilities] = await Promise.all([
+    db.molecules.findMany({
+      select: {
+        id: true,
+        createdat: true,
+        moleculesynonyms: {
+          select: { synonym: true, order: true },
+          orderBy: [{ order: "asc" }, { synonym: "asc" }],
+          take: 1,
+        },
+      },
+      take: 1000,
+    }),
+    db.facilities.findMany({
+      select: { id: true },
+      take: 1000,
+    }),
+  ]);
+
+  const moleculeEntries: MetadataRoute.Sitemap = molecules.map((molecule) => {
+    const primarySynonym = molecule.moleculesynonyms[0]?.synonym?.trim() ?? molecule.id;
+    const slug = slugifyMoleculeSynonym(primarySynonym);
+    return {
+      url: `${baseUrl}/molecules/${slug}`,
+      lastModified: molecule.createdat ?? now,
+      changeFrequency: "weekly",
+      priority: 0.75,
+    };
+  });
+
+  const facilityEntries: MetadataRoute.Sitemap = facilities.map((facility) => ({
+    url: `${baseUrl}/facilities/${facility.id}`,
+  lastModified: now,
+    changeFrequency: "weekly",
+    priority: 0.65,
+  }));
 
   return [
     {
-      url: "https://xrayatlas.wsu.edu",
+      url: baseUrl,
       lastModified: now,
       changeFrequency: "weekly",
       priority: 1,
     },
     {
-      url: "https://xrayatlas.wsu.edu/browse",
+      url: `${baseUrl}/browse/molecules`,
       lastModified: now,
       changeFrequency: "daily",
       priority: 0.9,
     },
     {
-      url: "https://xrayatlas.wsu.edu/browse/molecules",
+      url: `${baseUrl}/browse/nexafs`,
       lastModified: now,
       changeFrequency: "daily",
       priority: 0.9,
     },
     {
-      url: "https://xrayatlas.wsu.edu/browse/nexafs",
+      url: `${baseUrl}/browse/facilities`,
       lastModified: now,
       changeFrequency: "daily",
-      priority: 0.9,
+      priority: 0.8,
     },
     {
-      url: "https://xrayatlas.wsu.edu/contribute",
-      lastModified: now,
-      changeFrequency: "weekly",
-      priority: 0.7,
-    },
-    {
-      url: "https://xrayatlas.wsu.edu/facilities",
-      lastModified: now,
-      changeFrequency: "weekly",
-      priority: 0.7,
-    },
-    {
-      url: "https://xrayatlas.wsu.edu/about",
+      url: `${baseUrl}/about`,
       lastModified: now,
       changeFrequency: "weekly",
       priority: 0.75,
     },
     {
-      url: "https://xrayatlas.wsu.edu/wiki/home",
+      url: `${baseUrl}/wiki/home`,
       lastModified: now,
       changeFrequency: "weekly",
       priority: 0.65,
     },
     {
-      url: "https://xrayatlas.wsu.edu/wiki/data-representation",
+      url: `${baseUrl}/wiki/data-representation`,
       lastModified: now,
       changeFrequency: "weekly",
       priority: 0.65,
     },
     {
-      url: "https://xrayatlas.wsu.edu/wiki/platform-features",
+      url: `${baseUrl}/wiki/platform-features`,
       lastModified: now,
       changeFrequency: "weekly",
       priority: 0.65,
     },
     {
-      url: "https://xrayatlas.wsu.edu/wiki/contributions",
+      url: `${baseUrl}/wiki/contributions`,
       lastModified: now,
       changeFrequency: "weekly",
       priority: 0.65,
     },
+    ...moleculeEntries,
+    ...facilityEntries,
   ];
 }

--- a/src/app/users/[id]/layout.tsx
+++ b/src/app/users/[id]/layout.tsx
@@ -22,11 +22,32 @@ export async function generateMetadata({
 
   const displayName = user.name?.trim() ?? "User";
 
+  const moleculesAuthored = await db.molecules.count({
+    where: { createdby: user.id },
+  });
+
+  const countPhrase =
+    moleculesAuthored > 0
+      ? ` ${moleculesAuthored} molecule record${moleculesAuthored === 1 ? "" : "s"} contributed.`
+      : "";
+
+  const description = `Public contributor profile for ${displayName} on X-ray Atlas.${countPhrase}`.replace(/\s+/g, " ").trim();
+
   return {
     title: `${displayName} profile`,
-    description: `Profile and contributed molecule records for ${displayName} on X-ray Atlas.`,
+    description,
     alternates: {
       canonical: `/users/${user.id}`,
+    },
+    openGraph: {
+      title: `${displayName} | X-ray Atlas`,
+      description,
+      url: `/users/${user.id}`,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${displayName} | X-ray Atlas`,
+      description,
     },
   };
 }

--- a/src/app/users/[id]/layout.tsx
+++ b/src/app/users/[id]/layout.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { db } from "~/server/db";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+
+  const user = await db.user.findUnique({
+    where: { id },
+    select: { id: true, name: true },
+  });
+
+  if (!user) {
+    return {
+      title: "User not found",
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const displayName = user.name?.trim() ?? "User";
+
+  return {
+    title: `${displayName} profile`,
+    description: `Profile and contributed molecule records for ${displayName} on X-ray Atlas.`,
+    alternates: {
+      canonical: `/users/${user.id}`,
+    },
+  };
+}
+
+export default function UserDetailLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -284,6 +284,41 @@ export default function UserProfilePage({
         </Link>
       </div>
 
+      <nav
+        aria-label="Explore X-ray Atlas"
+        className="border-border-default mb-6 rounded-lg border px-4 py-3"
+      >
+        <p className="text-text-secondary mb-2 text-xs font-medium tracking-wide uppercase">
+          Explore
+        </p>
+        <ul className="text-text-secondary flex flex-wrap gap-x-4 gap-y-2 text-sm">
+          <li>
+            <Link
+              href="/browse/molecules"
+              className="text-accent hover:text-accent-dark font-medium underline-offset-2 hover:underline"
+            >
+              Browse molecules
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/browse/nexafs"
+              className="text-accent hover:text-accent-dark font-medium underline-offset-2 hover:underline"
+            >
+              Browse NEXAFS
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/wiki/contributions"
+              className="text-accent hover:text-accent-dark font-medium underline-offset-2 hover:underline"
+            >
+              Contributing data
+            </Link>
+          </li>
+        </ul>
+      </nav>
+
       <div className="border-border-default bg-surface-1 rounded-xl border p-8">
         <div className="flex flex-col items-center gap-6 sm:flex-row sm:items-start">
           <CustomAvatar user={user} size="lg" />

--- a/src/app/wiki/contributions/page.tsx
+++ b/src/app/wiki/contributions/page.tsx
@@ -10,6 +10,9 @@ export const metadata: Metadata = {
   title: "Database Contributions",
   description:
     `How to contribute NEXAFS datasets to ${site.name} with metadata quality, reproducibility, and citation-ready attribution.`,
+  alternates: {
+    canonical: "/wiki/contributions",
+  },
 };
 
 export default function ContributionsPage() {
@@ -57,6 +60,13 @@ export default function ContributionsPage() {
             Open contribution flow
           </Link>
         </div>
+        <p className="text-muted mt-4 text-sm">
+          Before submitting, review{" "}
+          <Link href="/wiki/data-representation" className="text-accent hover:underline">
+            data representation and structure
+          </Link>
+          {" "}to keep uploaded fields aligned with browse filters and analysis views.
+        </p>
       </section>
     </div>
   );

--- a/src/app/wiki/data-representation/page.tsx
+++ b/src/app/wiki/data-representation/page.tsx
@@ -11,6 +11,9 @@ export const metadata: Metadata = {
   title: "Data Representation and Structure",
   description:
     `How ${site.name} represents molecules, samples, experiments, and spectroscopy traces for robust querying and scientific reuse.`,
+  alternates: {
+    canonical: "/wiki/data-representation",
+  },
 };
 
 export default function DataRepresentationPage() {
@@ -76,10 +79,18 @@ export default function DataRepresentationPage() {
       </div>
       <p className="text-muted">
         To query these fields directly, start with{" "}
-        <Link href="/browse" className="text-accent hover:underline">
-          the browse interface
+        <Link href="/browse/molecules" className="text-accent hover:underline">
+          molecule browse
         </Link>
-        .
+        {" "}for identity and composition filters,{" "}
+        <Link href="/browse/nexafs" className="text-accent hover:underline">
+          NEXAFS browse
+        </Link>
+        {" "}for edge and geometry comparisons, and{" "}
+        <Link href="/wiki/contributions" className="text-accent hover:underline">
+          contribution guidelines
+        </Link>
+        {" "}for metadata completeness before upload.
       </p>
     </div>
   );

--- a/src/app/wiki/home/page.tsx
+++ b/src/app/wiki/home/page.tsx
@@ -4,6 +4,7 @@
 
 import type { ComponentType } from "react";
 import type { Metadata } from "next";
+import Link from "next/link";
 import { NexafsCoreAbsorptionSchematic } from "~/components/nexafs/nexafs-core-absorption-schematic";
 import { site } from "~/app/brand";
 import {
@@ -14,9 +15,12 @@ import {
 } from "@heroicons/react/24/outline";
 
 export const metadata: Metadata = {
-  title: "Wiki home",
+  title: "NEXAFS wiki home",
   description:
     `NEXAFS reference for terminology, scientific targets, and interpretation context used across the ${site.name} spectroscopy database.`,
+  alternates: {
+    canonical: "/wiki/home",
+  },
 };
 
 const terminologyCards = [
@@ -83,8 +87,8 @@ export default function NexafsWikiPage() {
   return (
     <div className="w-full min-w-0 space-y-10">
         <header className="@container border-border bg-surface/80 relative overflow-hidden rounded-2xl border px-6 py-8 sm:px-8 lg:py-10">
-          <h1 className="text-foreground text-3xl font-bold sm:text-4xl">
-            Home
+            <h1 className="text-foreground text-3xl font-bold sm:text-4xl">
+            NEXAFS wiki home
           </h1>
           <div
             className="pointer-events-none absolute inset-0 opacity-[0.07]"
@@ -232,6 +236,29 @@ export default function NexafsWikiPage() {
               comparable traces collected under different instrumental coupling.
             </li>
           </ul>
+        </section>
+        <section className="border-border bg-surface rounded-2xl border p-6 sm:p-8">
+          <SectionHeader
+            icon={BookOpenIcon}
+            title="Apply this in the catalog"
+            id="catalog-links"
+          />
+          <p className="text-muted max-w-none text-sm leading-relaxed">
+            Use these definitions while browsing and comparing records:
+            {" "}
+            <Link href="/browse/nexafs" className="text-accent hover:underline">
+              browse NEXAFS datasets
+            </Link>
+            ,{" "}
+            <Link href="/browse/molecules" className="text-accent hover:underline">
+              browse molecules
+            </Link>
+            , and{" "}
+            <Link href="/wiki/data-representation" className="text-accent hover:underline">
+              review data representation details
+            </Link>
+            .
+          </p>
         </section>
     </div>
   );

--- a/src/app/wiki/platform-features/page.tsx
+++ b/src/app/wiki/platform-features/page.tsx
@@ -10,6 +10,9 @@ export const metadata: Metadata = {
   title: "Platform Features",
   description:
     `Core ${site.name} features for searching, filtering, visualizing, and contributing NEXAFS and X-ray spectroscopy datasets.`,
+  alternates: {
+    canonical: "/wiki/platform-features",
+  },
 };
 
 const featureItems = [
@@ -76,6 +79,12 @@ export default function PlatformFeaturesPage() {
           className="border-border bg-surface text-foreground rounded-lg border px-4 py-2 text-sm font-medium"
         >
           Contribute datasets
+        </Link>
+        <Link
+          href="/wiki/data-representation"
+          className="border-border bg-surface text-foreground rounded-lg border px-4 py-2 text-sm font-medium"
+        >
+          Data representation guide
         </Link>
       </div>
     </div>

--- a/src/components/about/wiki-doc-shell.tsx
+++ b/src/components/about/wiki-doc-shell.tsx
@@ -44,8 +44,9 @@ import {
 const STORAGE_LEFT = "xray-atlas-wiki-aside-left";
 const STORAGE_RIGHT = "xray-atlas-wiki-aside-right";
 
-const WIKI_DOCS_TOP_OFFSET = "5.5rem";
-const WIKI_DOCS_PANEL_HEIGHT = `calc(100dvh - ${WIKI_DOCS_TOP_OFFSET} - 1.5rem)`;
+const WIKI_DOCS_TOP_OFFSET = "5rem";
+const WIKI_DOCS_PANEL_BOTTOM_GAP = "1rem";
+const WIKI_DOCS_PANEL_HEIGHT = `calc(100dvh - ${WIKI_DOCS_TOP_OFFSET} - ${WIKI_DOCS_PANEL_BOTTOM_GAP})`;
 
 const wikiRailTooltipClass =
   "bg-foreground text-background rounded-lg px-3 py-2 text-sm shadow-lg";
@@ -622,7 +623,13 @@ export function WikiDocShell({ children }: WikiDocShellProps): ReactElement {
 
       <Drawer.Backdrop isOpen={navDrawerOpen} onOpenChange={setNavDrawerOpen}>
         <Drawer.Content placement="left">
-          <Drawer.Dialog className="border-border bg-background flex h-full max-w-[min(100vw-2rem,22rem)] flex-col border-r">
+          <Drawer.Dialog
+            className="border-border bg-background flex max-w-[min(100vw-2rem,22rem)] flex-col border-r"
+            style={{
+              marginTop: WIKI_DOCS_TOP_OFFSET,
+              height: WIKI_DOCS_PANEL_HEIGHT,
+            }}
+          >
             <Drawer.CloseTrigger />
             <Drawer.Header>
               <Drawer.Heading className="text-base">Overview</Drawer.Heading>
@@ -639,7 +646,13 @@ export function WikiDocShell({ children }: WikiDocShellProps): ReactElement {
 
       <Drawer.Backdrop isOpen={tocDrawerOpen} onOpenChange={setTocDrawerOpen}>
         <Drawer.Content placement="right">
-          <Drawer.Dialog className="border-border bg-background flex h-full max-w-[min(100vw-2rem,22rem)] flex-col border-l">
+          <Drawer.Dialog
+            className="border-border bg-background flex max-w-[min(100vw-2rem,22rem)] flex-col border-l"
+            style={{
+              marginTop: WIKI_DOCS_TOP_OFFSET,
+              height: WIKI_DOCS_PANEL_HEIGHT,
+            }}
+          >
             <Drawer.CloseTrigger />
             <Drawer.Header>
               <Drawer.Heading className="text-base">On this page</Drawer.Heading>

--- a/src/components/browse/molecule-detail-layout-client.tsx
+++ b/src/components/browse/molecule-detail-layout-client.tsx
@@ -69,6 +69,17 @@ export function MoleculeDetailLayoutClient({
               <li aria-hidden className="text-gray-400 dark:text-gray-600">
                 /
               </li>
+              <li>
+                <Link
+                  href="/wiki/home"
+                  className="hover:text-accent dark:hover:text-accent-light"
+                >
+                  NEXAFS wiki
+                </Link>
+              </li>
+              <li aria-hidden className="text-gray-400 dark:text-gray-600">
+                /
+              </li>
               <li
                 className="text-gray-900 dark:text-gray-100"
                 aria-current="page"

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -70,16 +70,28 @@ export function Footer() {
             </h4>
             <div className="flex flex-col space-y-2">
               <Link
-                href="/browse"
+                href="/browse/molecules"
                 className="text-muted text-sm transition-colors hover:text-accent hover:underline"
               >
-                Browse
+                Browse molecules
+              </Link>
+              <Link
+                href="/browse/nexafs"
+                className="text-muted text-sm transition-colors hover:text-accent hover:underline"
+              >
+                Browse NEXAFS
               </Link>
               <Link
                 href="/contribute"
                 className="text-muted text-sm transition-colors hover:text-accent hover:underline"
               >
                 Contribute
+              </Link>
+              <Link
+                href="/wiki/home"
+                className="text-muted text-sm transition-colors hover:text-accent hover:underline"
+              >
+                NEXAFS wiki
               </Link>
               <Link
                 href="/about"

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -22,6 +22,7 @@ import { site } from "~/app/brand";
 
 function AboutDropdown() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isWikiOpen, setIsWikiOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
@@ -32,6 +33,7 @@ function AboutDropdown() {
         !dropdownRef.current.contains(event.target as Node)
       ) {
         setIsOpen(false);
+        setIsWikiOpen(false);
       }
     }
 
@@ -47,6 +49,7 @@ function AboutDropdown() {
   const handleItemClick = (path: string) => {
     router.push(path);
     setIsOpen(false);
+    setIsWikiOpen(false);
   };
 
   return (
@@ -68,7 +71,7 @@ function AboutDropdown() {
       </button>
 
       {isOpen ? (
-        <div className="border-border bg-surface absolute top-full left-0 z-50 mt-2 w-48 rounded-lg border shadow-lg">
+        <div className="border-border bg-surface absolute top-full left-0 z-50 mt-2 w-60 rounded-lg border shadow-lg">
           <div className="py-1">
             <button
               type="button"
@@ -78,14 +81,59 @@ function AboutDropdown() {
               <InformationCircleIcon className="text-accent h-4 w-4" />
               <span>About</span>
             </button>
-            <button
-              type="button"
-              onClick={() => handleItemClick("/wiki/home")}
-              className="text-foreground hover:bg-default flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors"
-            >
-              <BookOpenIcon className="text-accent h-4 w-4" />
-              <span>Wiki</span>
-            </button>
+            <div className="border-border mx-2 my-1 rounded-md border bg-default/30 py-1">
+              <button
+                type="button"
+                onClick={() => setIsWikiOpen((prev) => !prev)}
+                className="text-foreground hover:bg-default flex w-full items-center gap-3 px-3 py-2 text-left text-sm font-medium transition-colors"
+                aria-expanded={isWikiOpen}
+                aria-controls="about-wiki-accordion"
+              >
+                <BookOpenIcon className="text-accent h-4 w-4" />
+                <span>Wiki</span>
+                <ChevronDown
+                  className={`ml-auto h-3.5 w-3.5 transition-transform ${
+                    isWikiOpen ? "rotate-180" : ""
+                  }`}
+                />
+              </button>
+              {isWikiOpen ? (
+                <div id="about-wiki-accordion" className="mt-1 space-y-0.5 pb-1">
+                  <button
+                    type="button"
+                    onClick={() => handleItemClick("/wiki/home")}
+                    className="text-foreground hover:bg-default flex w-full items-center gap-3 px-3 py-2 pl-9 text-left text-sm transition-colors"
+                  >
+                    <BookOpenIcon className="text-accent h-4 w-4" />
+                    <span>Wiki home</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleItemClick("/wiki/data-representation")}
+                    className="text-foreground hover:bg-default flex w-full items-center gap-3 px-3 py-2 pl-9 text-left text-sm transition-colors"
+                  >
+                    <BookOpenIcon className="text-accent h-4 w-4" />
+                    <span>Data representation</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleItemClick("/wiki/platform-features")}
+                    className="text-foreground hover:bg-default flex w-full items-center gap-3 px-3 py-2 pl-9 text-left text-sm transition-colors"
+                  >
+                    <BookOpenIcon className="text-accent h-4 w-4" />
+                    <span>Platform features</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleItemClick("/wiki/contributions")}
+                    className="text-foreground hover:bg-default flex w-full items-center gap-3 px-3 py-2 pl-9 text-left text-sm transition-colors"
+                  >
+                    <BookOpenIcon className="text-accent h-4 w-4" />
+                    <span>Contribution guide</span>
+                  </button>
+                </div>
+              ) : null}
+            </div>
             <button
               type="button"
               onClick={() => handleItemClick("/privacy")}

--- a/src/components/molecules/molecule-display.tsx
+++ b/src/components/molecules/molecule-display.tsx
@@ -235,7 +235,7 @@ export const MoleculeDecriptionTags = ({
         >
           <Image
             src={PUBCHEM_FAVICON_URL}
-            alt=""
+            alt="PubChem registry icon"
             width={16}
             height={16}
             className="h-4 w-4 object-contain"
@@ -251,7 +251,7 @@ export const MoleculeDecriptionTags = ({
         >
           <Image
             src={CAS_FAVICON_URL}
-            alt=""
+            alt="CAS registry icon"
             width={16}
             height={16}
             className="h-4 w-4 object-contain"
@@ -295,7 +295,7 @@ function MoleculeRegistryFaviconLinks({
             >
               <Image
                 src={CAS_FAVICON_URL}
-                alt=""
+                alt="CAS registry icon"
                 width={20}
                 height={20}
                 className="h-5 w-5 object-contain"
@@ -313,7 +313,7 @@ function MoleculeRegistryFaviconLinks({
           >
             <Image
               src={CAS_FAVICON_URL}
-              alt=""
+              alt="CAS registry icon unavailable"
               width={20}
               height={20}
               className="h-5 w-5 object-contain opacity-50"
@@ -336,7 +336,7 @@ function MoleculeRegistryFaviconLinks({
             >
               <Image
                 src={PUBCHEM_FAVICON_URL}
-                alt=""
+                alt="PubChem registry icon"
                 width={20}
                 height={20}
                 className="h-5 w-5 object-contain"
@@ -354,7 +354,7 @@ function MoleculeRegistryFaviconLinks({
           >
             <Image
               src={PUBCHEM_FAVICON_URL}
-              alt=""
+              alt="PubChem registry icon unavailable"
               width={20}
               height={20}
               className="h-5 w-5 object-contain opacity-50"
@@ -1436,7 +1436,7 @@ function HeaderCardIdentifierRow({
       >
         <Image
           src={CAS_FAVICON_URL}
-          alt=""
+          alt="CAS registry icon"
           width={16}
           height={16}
           className="h-4 w-4 shrink-0 object-contain"
@@ -1503,7 +1503,7 @@ function HeaderCardIdentifierRow({
       >
         <Image
           src={PUBCHEM_FAVICON_URL}
-          alt=""
+          alt="PubChem registry icon"
           width={16}
           height={16}
           className="h-4 w-4 shrink-0 object-contain"

--- a/src/lib/molecule-schema-org.ts
+++ b/src/lib/molecule-schema-org.ts
@@ -1,0 +1,139 @@
+import type { MoleculeView } from "~/types/molecule";
+
+/**
+ * Builds concise molecule detail title and meta description for `generateMetadata` (no keyword stuffing).
+ *
+ * @param view - Molecule DTO from tRPC `molecules.getById` / `getBySlug`.
+ * @returns `title` respects root `metadata.title.template`; `description` stays readable with optional formula, CAS, PubChem CID, and dataset count.
+ */
+export function buildMoleculeDetailSeoText(view: MoleculeView): {
+  title: string;
+  description: string;
+} {
+  const name = view.name.trim();
+  const formula = view.chemicalFormula.trim();
+  const formulaSuffix = formula.length > 0 ? ` (${formula})` : "";
+  const title = `${name}${formulaSuffix} NEXAFS datasets`;
+
+  const lead =
+    formula.length > 0
+      ? `${name} (${formula}) on X-ray Atlas.`
+      : `${name} on X-ray Atlas.`;
+
+  const idParts: string[] = [];
+  const cas = view.casNumber?.trim();
+  if (cas && cas.length > 0) idParts.push(`CAS ${cas}`);
+  const cid = view.pubChemCid?.trim();
+  if (cid && cid.length > 0) idParts.push(`PubChem CID ${cid}`);
+  const idClause =
+    idParts.length > 0 ? ` ${idParts.join("; ")}.` : "";
+
+  const n = view.experimentCount ?? 0;
+  const tail =
+    n > 0
+      ? ` ${n} NEXAFS dataset${n === 1 ? "" : "s"} and linked spectroscopy metadata.`
+      : " Molecular identifiers and linked spectroscopy metadata.";
+
+  const description = `${lead}${idClause}${tail}`.replace(/\s+/g, " ").trim();
+
+  return { title, description };
+}
+
+/**
+ * Production origin used for absolute molecule URLs in JSON-LD `url` and related fields.
+ * Matches `metadataBase` in `src/app/metadata.ts`.
+ */
+export const SITE_CANONICAL_ORIGIN = "https://xrayatlas.wsu.edu";
+
+/**
+ * Builds a schema.org JSON-LD node for a public molecule page using `ChemicalSubstance` and
+ * `MolecularEntity` types. Omits optional properties when values are empty after trim.
+ *
+ * @param view - Molecule DTO from `toMoleculeView` / tRPC `molecules.getById` or `getBySlug`.
+ * @param canonicalSlug - Path slug from `canonicalMoleculeSlugFromView` (not a UUID).
+ * @returns A plain object suitable for `JSON.stringify` inside `application/ld+json`.
+ */
+export function buildMoleculeChemicalSubstanceJsonLd(
+  view: MoleculeView,
+  canonicalSlug: string,
+): Record<string, unknown> {
+  const url = `${SITE_CANONICAL_ORIGIN}/molecules/${canonicalSlug}`;
+  const primary = view.name.trim();
+  const alternateNames = (view.commonName ?? [])
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && s !== primary)
+    .slice(0, 12);
+
+  const node: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": ["ChemicalSubstance", "MolecularEntity"],
+    name: primary,
+    url,
+  };
+
+  if (alternateNames.length === 1) {
+    node.alternateName = alternateNames[0];
+  } else if (alternateNames.length > 1) {
+    node.alternateName = alternateNames;
+  }
+
+  const iupac = view.iupacName.trim();
+  if (iupac.length > 0 && iupac !== primary) {
+    node.iupacName = iupac;
+  }
+
+  const formula = view.chemicalFormula.trim();
+  if (formula.length > 0) {
+    node.molecularFormula = formula;
+  }
+
+  const inchi = view.InChI.trim();
+  if (inchi.length > 0) {
+    node.inChI = inchi.startsWith("InChI=") ? inchi : `InChI=${inchi}`;
+  }
+
+  const smiles = view.SMILES.trim();
+  if (smiles.length > 0) {
+    node.smiles = smiles;
+  }
+
+  const identifiers: Array<Record<string, unknown>> = [];
+  const cas = view.casNumber?.trim();
+  if (cas && cas.length > 0) {
+    identifiers.push({
+      "@type": "PropertyValue",
+      name: "CAS Registry Number",
+      value: cas,
+    });
+  }
+  const cid = view.pubChemCid?.trim();
+  if (cid && cid.length > 0) {
+    identifiers.push({
+      "@type": "PropertyValue",
+      name: "PubChem compound",
+      value: cid,
+    });
+  }
+  if (identifiers.length === 1) {
+    node.identifier = identifiers[0];
+  } else if (identifiers.length > 1) {
+    node.identifier = identifiers;
+  }
+
+  if (cid && cid.length > 0) {
+    node.sameAs = `https://pubchem.ncbi.nlm.nih.gov/compound/${encodeURIComponent(cid)}`;
+  }
+
+  return node;
+}
+
+/**
+ * Serializes JSON-LD for a `<script type="application/ld+json">` tag; escapes `<` for HTML embedding.
+ *
+ * @param data - Object from `buildMoleculeChemicalSubstanceJsonLd`.
+ */
+export function serializeMoleculeJsonLdScriptContent(
+  data: Record<string, unknown>,
+): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}

--- a/tmp/brand.ts
+++ b/tmp/brand.ts
@@ -1,0 +1,109 @@
+/**
+ * Canonical brand and mission strings for X-ray Atlas.
+ *
+ * Usage convention mirrors CSS custom properties or i18n key paths:
+ *   brand.mission.heroShort  -> "mission.hero-short"
+ *   brand.mission.canonical  -> "mission.canonical"
+ *
+ * All copy here is the single source of truth. Consume these strings
+ * in page components, metadata, OG tags, and documentation rather than
+ * duplicating copy across files.
+ *
+ * tmp/ status: pending promotion to src/lib/brand.ts
+ */
+
+// ---------------------------------------------------------------------------
+// Site identity
+// ---------------------------------------------------------------------------
+
+export const site = {
+  name: "X-ray Atlas",
+  url: "https://xrayatlas.wsu.edu",
+  applicationName: "Xray Atlas",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Attribution
+// WSU Carbon Lab hosts and maintains the database. The platform serves the
+// broader synchrotron community but attribution to the originating lab is
+// preserved throughout.
+// ---------------------------------------------------------------------------
+
+export const attribution = {
+  lab: "WSU Carbon Lab",
+  labFull: "Washington State University Carbon Lab",
+  labUrl: "https://labs.wsu.edu/carbon/",
+  pi: "Brian Collins",
+  piTitle: "Prof. Brian Collins",
+  institution: "Washington State University",
+  institutionAbbr: "WSU",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Mission strings
+// Organized by context and audience. Prefer the shortest variant that is
+// still accurate for the given surface area.
+// ---------------------------------------------------------------------------
+
+export const mission = {
+  /**
+   * Hero short — homepage subheading, README tagline, social card fallback.
+   * Three declarative statements. No elaboration.
+   */
+  heroShort: "Search spectra. Trace provenance. Cite with confidence.",
+
+  /**
+   * Hero long — homepage hero when space allows a second line, or any
+   * surface that benefits from a framing sentence before the call to action.
+   */
+  heroLong:
+    "X-ray spectroscopy data that belongs to the community that made it. Search spectra. Trace provenance. Cite with confidence.",
+
+  /**
+   * Canonical — the definitive mission statement for the platform.
+   * Audience: any reader. Tone: clear, institutional, community-oriented.
+   * Use on the about page opening, grant language, and press materials.
+   */
+  canonical:
+    "X-ray Atlas is an open database for NEXAFS and X-ray absorption spectroscopy, built to make high-quality spectroscopy data findable, attributable, and reusable at the scale the field requires. Hosted by the WSU Carbon Lab and developed in collaboration with the synchrotron science community, the platform grounds every contributed spectrum in its experimental context and preserves contributor attribution across the full data lifecycle.",
+
+  /**
+   * Technical — for API docs, developer onboarding, and methods sections
+   * in publications. Audience: researchers and engineers who want to know
+   * what the system actually does before using it.
+   */
+  technical:
+    "X-ray Atlas provides a queryable, API-accessible repository for NEXAFS and X-ray absorption spectroscopy datasets. Each record links molecular identifiers, spectral traces, experimental conditions, facility provenance, and contributor attribution in a structured schema aligned with FAIR data principles. The platform assigns persistent identifiers to contributed records and exposes machine-readable endpoints designed for integration into analysis pipelines, reference databases, and AI-assisted discovery workflows.",
+
+  /**
+   * Stewardship — for grant applications, data management plans, and
+   * institutional communications. Emphasizes obligation, community
+   * infrastructure, and long-term data integrity.
+   */
+  stewardship:
+    "X-ray Atlas operates as community infrastructure for the synchrotron science community, with an explicit commitment to preserving experimental context and contributor attribution across the full data lifecycle. Every spectrum in the database carries its provenance forward — edge selection, sample geometry, instrument, facility, and originating researcher — because scientific reproducibility depends on that context remaining accessible alongside the data itself. The platform is maintained by the WSU Carbon Lab and developed in ongoing collaboration with researchers at ALS, NSLS-II, SSRL, and affiliated institutions, under open data licensing that treats publicly funded measurements as a shared community resource.",
+
+  /**
+   * SEO description — used in <meta name="description"> and OG/Twitter
+   * description tags. ~155 characters, keyword-dense, no truncation risk.
+   */
+  seoDescription:
+    "Open NEXAFS and X-ray absorption spectroscopy database. Search molecules, compare spectra, and cite data with full experimental provenance. Hosted by the WSU Carbon Lab.",
+
+  /**
+   * OG title — used in OpenGraph and Twitter card titles.
+   */
+  ogTitle: "X-ray Atlas | WSU Carbon Lab",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Composite export for convenience
+// ---------------------------------------------------------------------------
+
+export const brand = {
+  site,
+  attribution,
+  mission,
+} as const;
+
+export default brand;


### PR DESCRIPTION
## Summary

Improve SEO coverage across molecule, facility, and user detail surfaces with stronger metadata, canonical handling, structured data for molecule entities, and better internal linking to wiki/browse routes.

## Changes

- Add route-level metadata layouts for key indexable and non-indexable route groups, plus richer detail-route metadata for molecules, facilities, and users.
- Implement canonical redirect and metadata improvements for molecule detail, plus dynamic sitemap and tighter robots directives for low-value/private paths.
- Add molecule JSON-LD helpers and emit ChemicalSubstance structured data; improve internal link pathways in wiki/header/footer/detail pages and refine meaningful image alt text.

## Test Plan

- [x] Tested locally
- [ ] Tested OAuth flow (if auth changes)
- [ ] Tested on mobile (if UI changes)

## AI Role (required)

Choose one of the following and briefly justify it:

- [ ] Level 1: Mostly suggestions, tab completion, and minimal code generation
- [x] Level 2: Extensive code generation, but heavily managed; business and scientific logic was dictated by the contributor
- [ ] Level 3: Fully vibe coded; PRs using this level will likely be thrown away, but may contain nuggets a maintainer chooses to review

Validation used for this PR included local `bun run lint` and `bun run typecheck`, followed by focused UI verification of dropdown and detail-route behavior.

## Screenshots (if UI changes)

Before | After
--- | ---
img | img