### PR TITLE
feat(wiki): page navigation controls and wiki layout cleanup

### DIFF
--- a/src/components/about/api-v1-reference.tsx
+++ b/src/components/about/api-v1-reference.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { LinkIcon } from "@heroicons/react/24/outline";
+import { ChevronDownIcon, LinkIcon } from "@heroicons/react/24/outline";
 import { Accordion, Button } from "@heroui/react";
-import { useMemo } from "react";
+import { type ReactElement, useMemo } from "react";
 
 type RouteDoc = {
   readonly path: string;
@@ -17,20 +17,36 @@ const moleculesRoutes: readonly RouteDoc[] = [
     path: "/api/v1/molecules",
     method: "GET",
     description: "List molecules with search and pagination filters.",
-    query: ["q", "hasCas", "synonymsCountMax", "synonymsLimit", "limit", "offset"],
-    optional: ["q", "hasCas", "synonymsCountMax", "synonymsLimit", "limit", "offset"],
+    query: [
+      "q",
+      "hasCas",
+      "synonymsCountMax",
+      "synonymsLimit",
+      "limit",
+      "offset",
+    ],
+    optional: [
+      "q",
+      "hasCas",
+      "synonymsCountMax",
+      "synonymsLimit",
+      "limit",
+      "offset",
+    ],
   },
   {
     path: "/api/v1/molecules/{moleculeId}/edges",
     method: "GET",
-    description: "Summarize edge availability for a molecule, optionally scoped by DOI.",
+    description:
+      "Summarize edge availability for a molecule, optionally scoped by DOI.",
     query: ["doi"],
     optional: ["doi"],
   },
   {
     path: "/api/v1/molecules/search",
     method: "GET",
-    description: "Compatibility route that 307-redirects to legacy /api/molecules/search.",
+    description:
+      "Compatibility route that 307-redirects to legacy /api/molecules/search.",
     query: ["q", "query", "search", "s", "any passthrough query params"],
     optional: ["all query parameters are optional passthrough"],
   },
@@ -40,14 +56,16 @@ const datasetRoutes: readonly RouteDoc[] = [
   {
     path: "/api/v1/datasets",
     method: "GET",
-    description: "List dataset summaries filterable by molecule, edge, and DOI.",
+    description:
+      "List dataset summaries filterable by molecule, edge, and DOI.",
     query: ["moleculeId", "edgeId", "doi", "limit", "offset"],
     optional: ["moleculeId", "edgeId", "doi", "limit", "offset"],
   },
   {
     path: "/api/v1/datasets/discover",
     method: "GET",
-    description: "DOI-first dataset discovery with optional molecule or edge narrowing.",
+    description:
+      "DOI-first dataset discovery with optional molecule or edge narrowing.",
     query: ["doi", "moleculeId", "edgeId"],
     optional: ["moleculeId", "edgeId"],
   },
@@ -62,7 +80,7 @@ const datasetRoutes: readonly RouteDoc[] = [
 
 function MethodBadge({ method }: { method: RouteDoc["method"] }) {
   return (
-    <span className="rounded bg-accent/15 px-2 py-0.5 text-xs font-semibold tracking-wide text-accent">
+    <span className="bg-accent/15 text-accent rounded px-2 py-0.5 text-xs font-semibold tracking-wide">
       {method}
     </span>
   );
@@ -103,7 +121,8 @@ function RouteCard({ route }: { route: RouteDoc }) {
       </div>
       <p className="text-muted text-sm">{route.description}</p>
       <p className="text-muted text-sm">
-        <span className="text-foreground font-medium">Authentication:</span> none required.
+        <span className="text-foreground font-medium">Authentication:</span>{" "}
+        none required.
       </p>
       <p className="text-muted text-sm">
         <span className="text-foreground font-medium">Query keys:</span>{" "}
@@ -113,8 +132,44 @@ function RouteCard({ route }: { route: RouteDoc }) {
         <span className="text-foreground font-medium">Optional:</span>{" "}
         {route.optional.map((q) => `\`${q}\``).join(", ")}
       </p>
-      <CopyRouteButton path={route.path.replace("{moleculeId}", "YOUR_MOLECULE_ID")} />
+      <CopyRouteButton
+        path={route.path.replace("{moleculeId}", "YOUR_MOLECULE_ID")}
+      />
     </div>
+  );
+}
+
+interface RouteGroup {
+  readonly id: string;
+  readonly label: string;
+  readonly routes: readonly RouteDoc[];
+}
+
+const routeGroups: readonly RouteGroup[] = [
+  { id: "molecules-routes", label: "Molecules", routes: moleculesRoutes },
+  { id: "datasets-routes", label: "Datasets", routes: datasetRoutes },
+];
+
+function RouteGroupTrigger({
+  label,
+  count,
+}: {
+  label: string;
+  count: number;
+}): ReactElement {
+  return (
+    <Accordion.Trigger className="hover:bg-default/40 flex w-full items-center gap-3 rounded-md px-1 py-1 text-left text-sm font-semibold transition-colors">
+      <span className="min-w-0 flex-1">{label}</span>
+      <span className="border-border bg-default/40 text-muted shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium">
+        {count} {count === 1 ? "route" : "routes"}
+      </span>
+      <Accordion.Indicator>
+        <ChevronDownIcon
+          className="text-muted size-4 shrink-0 transition-transform"
+          aria-hidden
+        />
+      </Accordion.Indicator>
+    </Accordion.Trigger>
   );
 }
 
@@ -123,12 +178,16 @@ export function ApiV1Reference() {
     <div className="w-full min-w-0 space-y-6">
       <h1 className="text-foreground text-4xl font-bold">v1</h1>
       <section className="border-border bg-surface rounded-lg border p-4">
-        <h2 id="overview" className="text-foreground mb-2 text-lg font-semibold">
+        <h2
+          id="overview"
+          className="text-foreground mb-2 text-lg font-semibold"
+        >
           Route groups
         </h2>
         <p className="text-muted text-sm">
-          This page groups public routes by domain and documents available HTTP methods, accepted
-          request parameters, and direct API links.
+          This page groups public routes by domain and documents available HTTP
+          methods, accepted request parameters, and direct API links. Expand a
+          group below to see individual routes.
         </p>
       </section>
       <section className="border-border bg-surface rounded-lg border p-4">
@@ -136,30 +195,23 @@ export function ApiV1Reference() {
           API reference
         </h2>
         <Accordion allowsMultipleExpanded variant="surface">
-          <Accordion.Item id="molecules-routes">
-            <Accordion.Heading>
-              <Accordion.Trigger className="font-medium">Molecules</Accordion.Trigger>
-            </Accordion.Heading>
-            <Accordion.Panel>
-              <Accordion.Body className="space-y-3">
-                {moleculesRoutes.map((route) => (
-                  <RouteCard key={route.path} route={route} />
-                ))}
-              </Accordion.Body>
-            </Accordion.Panel>
-          </Accordion.Item>
-          <Accordion.Item id="datasets-routes">
-            <Accordion.Heading>
-              <Accordion.Trigger className="font-medium">Datasets</Accordion.Trigger>
-            </Accordion.Heading>
-            <Accordion.Panel>
-              <Accordion.Body className="space-y-3">
-                {datasetRoutes.map((route) => (
-                  <RouteCard key={route.path} route={route} />
-                ))}
-              </Accordion.Body>
-            </Accordion.Panel>
-          </Accordion.Item>
+          {routeGroups.map((group) => (
+            <Accordion.Item key={group.id} id={group.id}>
+              <Accordion.Heading>
+                <RouteGroupTrigger
+                  label={group.label}
+                  count={group.routes.length}
+                />
+              </Accordion.Heading>
+              <Accordion.Panel>
+                <Accordion.Body className="space-y-3">
+                  {group.routes.map((route) => (
+                    <RouteCard key={route.path} route={route} />
+                  ))}
+                </Accordion.Body>
+              </Accordion.Panel>
+            </Accordion.Item>
+          ))}
         </Accordion>
       </section>
     </div>

--- a/src/components/about/wiki-doc-page-nav.tsx
+++ b/src/components/about/wiki-doc-page-nav.tsx
@@ -1,0 +1,222 @@
+/**
+ * Inline page navigation controls rendered at the top of every `/wiki/*` page.
+ *
+ * Exposes a "Copy page" action that copies the rendered wiki article HTML (and a plain
+ * text fallback) from the `[data-wiki-main]` region to the system clipboard, and a paired
+ * Previous / Next pair that walks {@link wikiDocPages} in reading order. Missing neighbors
+ * are omitted at the ends of the wiki sequence so the home page only offers a `Next` jump
+ * and the final API page only offers a `Previous` jump.
+ */
+
+"use client";
+
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  CheckIcon,
+  Square2StackIcon,
+} from "@heroicons/react/24/outline";
+import { Button, Tooltip } from "@heroui/react";
+import { cn } from "@heroui/styles";
+import Link from "next/link";
+import { useCallback, useEffect, useState, type ReactElement } from "react";
+import { wikiDocPageNeighbors, type WikiDocPage } from "~/lib/wiki-doc-nav";
+
+const wikiPageNavTooltipClass =
+  "bg-foreground text-background rounded-lg px-3 py-2 text-sm shadow-lg";
+
+const navIconButtonClass =
+  "border-border bg-background text-foreground hover:bg-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 size-9 shrink-0 rounded-lg border inline-flex items-center justify-center transition-colors";
+
+const COPY_FEEDBACK_MS = 1500;
+
+interface WikiDocPageNavProps {
+  /**
+   * Current Next.js pathname (without query or hash). Used to derive previous and next
+   * neighbors via {@link wikiDocPageNeighbors}.
+   */
+  pathname: string;
+}
+
+interface NeighborButtonProps {
+  direction: "previous" | "next";
+  page: WikiDocPage | undefined;
+}
+
+function NeighborButton({
+  direction,
+  page,
+}: NeighborButtonProps): ReactElement | null {
+  const isPrev = direction === "previous";
+  const Icon = isPrev ? ArrowLeftIcon : ArrowRightIcon;
+  const directionLabel = isPrev ? "Previous page" : "Next page";
+
+  if (!page) {
+    return null;
+  }
+
+  return (
+    <Link
+      aria-label={`${directionLabel}: ${page.label}`}
+      className={navIconButtonClass}
+      href={page.href}
+      title={`${isPrev ? "Previous" : "Next"}: ${page.label}`}
+    >
+      <Icon className="size-4 shrink-0" aria-hidden />
+      <span className="sr-only">{`${isPrev ? "Previous" : "Next"}: ${page.label}`}</span>
+    </Link>
+  );
+}
+
+function readWikiArticle(): { html: string; text: string } | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const article = document.querySelector<HTMLElement>("[data-wiki-main]");
+  if (!article) {
+    return null;
+  }
+  return {
+    html: article.outerHTML,
+    text: article.innerText.trim(),
+  };
+}
+
+async function copyArticleToClipboard(): Promise<boolean> {
+  const article = readWikiArticle();
+  if (!article || article.html.length === 0) {
+    return false;
+  }
+
+  const canWriteRich =
+    typeof window !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    typeof window.ClipboardItem !== "undefined" &&
+    typeof navigator.clipboard?.write === "function";
+
+  if (canWriteRich) {
+    try {
+      const item = new window.ClipboardItem({
+        "text/html": new Blob([article.html], { type: "text/html" }),
+        "text/plain": new Blob([article.text], { type: "text/plain" }),
+      });
+      await navigator.clipboard.write([item]);
+      return true;
+    } catch {
+      // Fall through to plain-text fallbacks below.
+    }
+  }
+
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(article.text);
+      return true;
+    } catch {
+      // Fall through to legacy fallback below.
+    }
+  }
+
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = article.text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "absolute";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(textarea);
+  return ok;
+}
+
+/**
+ * Renders the Copy page / Previous / Next button cluster for a wiki page.
+ *
+ * Copy targets the `[data-wiki-main]` article element rendered by `WikiDocShell` and
+ * writes both `text/html` and `text/plain` clipboard payloads when the modern Clipboard
+ * API is available, falling back to plain text and ultimately a `document.execCommand`
+ * textarea hop in non-secure contexts. Missing neighbors are omitted at the wiki sequence
+ * ends so the home page has no `Previous` target and the final page has no `Next` target.
+ *
+ * @param props.pathname - Current pathname (no query or hash).
+ */
+export function WikiDocPageNav({
+  pathname,
+}: WikiDocPageNavProps): ReactElement {
+  const { previous, next } = wikiDocPageNeighbors(pathname);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const id = window.setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    return () => window.clearTimeout(id);
+  }, [copied]);
+
+  const handleCopy = useCallback(async (): Promise<void> => {
+    const ok = await copyArticleToClipboard();
+    setCopied(ok);
+  }, []);
+
+  const CopyIcon = copied ? CheckIcon : Square2StackIcon;
+
+  return (
+    <nav
+      className="flex shrink-0 items-center gap-2"
+      aria-label="Page navigation"
+    >
+      <Tooltip delay={150}>
+        <Button
+          aria-label={copied ? "Page HTML copied" : "Copy page HTML"}
+          className={cn(
+            "h-9 gap-2 rounded-lg px-3 text-sm font-medium",
+            copied && "border-accent bg-accent/15 text-accent",
+          )}
+          variant="outline"
+          onPress={() => {
+            void handleCopy();
+          }}
+        >
+          <CopyIcon className="size-4 shrink-0" aria-hidden />
+          <span className="hidden sm:inline">
+            {copied ? "Copied" : "Copy Page"}
+          </span>
+        </Button>
+        <Tooltip.Content className={wikiPageNavTooltipClass} placement="bottom">
+          {copied ? "Page HTML copied to clipboard" : "Copy this page's HTML"}
+        </Tooltip.Content>
+      </Tooltip>
+      {previous ? (
+        <Tooltip delay={150}>
+          <NeighborButton direction="previous" page={previous} />
+          <Tooltip.Content
+            className={wikiPageNavTooltipClass}
+            placement="bottom start"
+          >
+            {`Previous: ${previous.label}`}
+          </Tooltip.Content>
+        </Tooltip>
+      ) : null}
+      {next ? (
+        <Tooltip delay={150}>
+          <NeighborButton direction="next" page={next} />
+          <Tooltip.Content
+            className={wikiPageNavTooltipClass}
+            placement="bottom end"
+          >
+            {`Next: ${next.label}`}
+          </Tooltip.Content>
+        </Tooltip>
+      ) : null}
+    </nav>
+  );
+}

--- a/src/components/about/wiki-doc-shell.tsx
+++ b/src/components/about/wiki-doc-shell.tsx
@@ -31,7 +31,7 @@ import {
   type ReactNode,
 } from "react";
 import {
-  wikiDocTopicForPathname,
+  wikiDocBreadcrumbTrail,
   wikiDocTopics,
   type WikiOverviewNavIcon,
 } from "~/lib/wiki-doc-nav";
@@ -447,7 +447,10 @@ export function WikiDocShell({ children }: WikiDocShellProps): ReactElement {
   const [hashId, setHashId] = useState("");
   const [isLgViewport, setIsLgViewport] = useState(false);
 
-  const current = useMemo(() => wikiDocTopicForPathname(pathname), [pathname]);
+  const breadcrumbTrail = useMemo(
+    () => wikiDocBreadcrumbTrail(pathname),
+    [pathname],
+  );
 
   const rescanToc = useCallback(() => {
     const root = mainRef.current?.querySelector("[data-wiki-main]");
@@ -615,9 +618,21 @@ export function WikiDocShell({ children }: WikiDocShellProps): ReactElement {
         <Breadcrumbs className="min-w-0 text-sm font-medium">
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/wiki/home">Wiki</Breadcrumbs.Item>
-          <Breadcrumbs.Item>
-            {current?.breadcrumbLabel ?? "Wiki"}
-          </Breadcrumbs.Item>
+          {breadcrumbTrail.length === 0 ? (
+            <Breadcrumbs.Item>Wiki</Breadcrumbs.Item>
+          ) : (
+            breadcrumbTrail.map((item, index) => {
+              const isTerminal = index === breadcrumbTrail.length - 1;
+              return (
+                <Breadcrumbs.Item
+                  key={`${item.label}-${item.href ?? "terminal"}`}
+                  href={!isTerminal && item.href ? item.href : undefined}
+                >
+                  {item.label}
+                </Breadcrumbs.Item>
+              );
+            })
+          )}
         </Breadcrumbs>
         <div className="flex shrink-0 items-center gap-2">
           <WikiDocPageNav pathname={pathname} />

--- a/src/components/about/wiki-doc-shell.tsx
+++ b/src/components/about/wiki-doc-shell.tsx
@@ -17,13 +17,7 @@ import {
   ListBulletIcon,
   SparklesIcon,
 } from "@heroicons/react/24/outline";
-import {
-  Accordion,
-  Breadcrumbs,
-  Button,
-  Drawer,
-  Tooltip,
-} from "@heroui/react";
+import { Accordion, Breadcrumbs, Button, Drawer, Tooltip } from "@heroui/react";
 import { cn } from "@heroui/styles";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -41,6 +35,7 @@ import {
   wikiDocTopics,
   type WikiOverviewNavIcon,
 } from "~/lib/wiki-doc-nav";
+import { WikiDocPageNav } from "./wiki-doc-page-nav";
 
 const STORAGE_LEFT = "xray-atlas-wiki-aside-left";
 const STORAGE_RIGHT = "xray-atlas-wiki-aside-right";
@@ -63,7 +58,11 @@ interface WikiDocShellProps {
   children: ReactNode;
 }
 
-function OverviewNavIcon({ kind }: { kind: WikiOverviewNavIcon }): ReactElement {
+function OverviewNavIcon({
+  kind,
+}: {
+  kind: WikiOverviewNavIcon;
+}): ReactElement {
   const cls = "text-accent size-4 shrink-0";
   switch (kind) {
     case "wiki-home":
@@ -124,7 +123,7 @@ function WikiOverviewAccordion({
             <Accordion.Heading>
               <Accordion.Trigger
                 className={cn(
-                  "text-sm flex w-full items-center gap-3",
+                  "flex w-full items-center gap-3 text-sm",
                   isActivePage && "text-accent font-medium",
                 )}
               >
@@ -148,7 +147,8 @@ function WikiOverviewAccordion({
                   const sectionActive = section.href
                     ? pathname === section.href
                     : isActivePage && hashId === section.id;
-                  const sectionHref = section.href ?? `${topic.href}#${section.id}`;
+                  const sectionHref =
+                    section.href ?? `${topic.href}#${section.id}`;
                   return (
                     <Link
                       key={section.id}
@@ -237,8 +237,11 @@ function OnThisPageAccordion({
     <Accordion className="w-full rounded-lg" variant="surface">
       <Accordion.Item defaultExpanded id="wiki-on-this-page">
         <Accordion.Heading>
-          <Accordion.Trigger className="text-sm font-semibold flex w-full items-center gap-3">
-            <ListBulletIcon className="text-accent size-5 shrink-0" aria-hidden />
+          <Accordion.Trigger className="flex w-full items-center gap-3 text-sm font-semibold">
+            <ListBulletIcon
+              className="text-accent size-5 shrink-0"
+              aria-hidden
+            />
             <span className="min-w-0 flex-1 text-left">On this page</span>
             <Accordion.Indicator>
               <ChevronDownIcon className="size-4 shrink-0" aria-hidden />
@@ -307,14 +310,10 @@ function WikiRailDock({
           <Button
             isIconOnly
             aria-expanded={panelOpen}
-            aria-label={
-              panelOpen ? `Collapse ${label}` : `Expand ${label}`
-            }
+            aria-label={panelOpen ? `Collapse ${label}` : `Expand ${label}`}
             className={cn(
               "border-border bg-background text-foreground hover:bg-default shrink-0 border",
-              minimized
-                ? "size-8 rounded-full"
-                : "size-9 rounded-lg",
+              minimized ? "size-8 rounded-full" : "size-9 rounded-lg",
               panelOpen &&
                 "border-accent bg-accent/15 text-accent ring-accent/25 ring-2",
             )}
@@ -342,7 +341,7 @@ function WikiRailDock({
         ) : null}
       </div>
       {panelOpen ? (
-        <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain px-2 pb-3 pt-2 [scrollbar-gutter:stable]">
+        <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain px-2 pt-2 pb-3 [scrollbar-gutter:stable]">
           {children}
         </div>
       ) : null}
@@ -415,7 +414,7 @@ function OnThisPageOutlinePanel({
   onNavigate?: () => void;
 }): ReactElement {
   return (
-    <div className="rounded-lg border border-border/60 bg-surface/40 px-2 py-2">
+    <div className="border-border/60 bg-surface/40 rounded-lg border px-2 py-2">
       <WikiOnPageOutline
         entries={toc}
         activeId={activeHeadingId}
@@ -442,9 +441,9 @@ export function WikiDocShell({ children }: WikiDocShellProps): ReactElement {
   const [showLeft, setShowLeft] = useState(true);
   const [showRight, setShowRight] = useState(true);
   const [hydrated, setHydrated] = useState(false);
-  const [overviewExpandedKeys, setOverviewExpandedKeys] = useState<
-    Set<string>
-  >(() => new Set());
+  const [overviewExpandedKeys, setOverviewExpandedKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [hashId, setHashId] = useState("");
   const [isLgViewport, setIsLgViewport] = useState(false);
 
@@ -535,7 +534,8 @@ export function WikiDocShell({ children }: WikiDocShellProps): ReactElement {
   }, [pathname, rescanToc]);
 
   useEffect(() => {
-    const hash = typeof window !== "undefined" ? window.location.hash.slice(1) : "";
+    const hash =
+      typeof window !== "undefined" ? window.location.hash.slice(1) : "";
     if (hash && toc.some((e) => e.id === hash)) {
       setActiveHeadingId(hash);
       return;
@@ -612,19 +612,22 @@ export function WikiDocShell({ children }: WikiDocShellProps): ReactElement {
   return (
     <div className="wiki-doc-shell text-foreground w-full min-w-0">
       <div className="border-border mb-4 flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-center sm:justify-between lg:mb-6">
-        <Breadcrumbs className="text-sm font-medium min-w-0">
+        <Breadcrumbs className="min-w-0 text-sm font-medium">
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/wiki/home">Wiki</Breadcrumbs.Item>
           <Breadcrumbs.Item>
             {current?.breadcrumbLabel ?? "Wiki"}
           </Breadcrumbs.Item>
         </Breadcrumbs>
-        <WikiMobileRailTriggers
-          outlineOpen={tocDrawerOpen}
-          overviewOpen={navDrawerOpen}
-          onOutlinePress={handleOutlineToggle}
-          onOverviewPress={handleOverviewToggle}
-        />
+        <div className="flex shrink-0 items-center gap-2">
+          <WikiDocPageNav pathname={pathname} />
+          <WikiMobileRailTriggers
+            outlineOpen={tocDrawerOpen}
+            overviewOpen={navDrawerOpen}
+            onOutlinePress={handleOutlineToggle}
+            onOverviewPress={handleOverviewToggle}
+          />
+        </div>
       </div>
 
       <Drawer.Backdrop isOpen={navDrawerOpen} onOpenChange={setNavDrawerOpen}>
@@ -661,7 +664,9 @@ export function WikiDocShell({ children }: WikiDocShellProps): ReactElement {
           >
             <Drawer.CloseTrigger />
             <Drawer.Header>
-              <Drawer.Heading className="text-base">On this page</Drawer.Heading>
+              <Drawer.Heading className="text-base">
+                On this page
+              </Drawer.Heading>
             </Drawer.Header>
             <Drawer.Body className="min-h-0 flex-1 overflow-y-auto px-3 pb-4">
               <OnThisPageAccordion
@@ -689,7 +694,7 @@ export function WikiDocShell({ children }: WikiDocShellProps): ReactElement {
         <div ref={mainRef} className="min-w-0 flex-1 lg:px-8">
           <div
             data-wiki-main
-            className="wiki-doc-main [&_h2[id]]:scroll-mt-28 [&_h3[id]]:scroll-mt-28 max-w-none"
+            className="wiki-doc-main max-w-none [&_h2[id]]:scroll-mt-28 [&_h3[id]]:scroll-mt-28"
           >
             {children}
           </div>

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -15,7 +15,7 @@ export function Footer() {
         <div className="mb-6 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <WSULogoIcon className="h-6 w-6" />
-            <span className="font-sans text-xl font-semibold text-foreground">
+            <span className="text-foreground font-sans text-xl font-semibold">
               {site.name}
             </span>
           </div>
@@ -25,12 +25,8 @@ export function Footer() {
         </div>
         <div className="grid grid-cols-1 gap-8 md:grid-cols-8">
           <div className="col-span-3 space-y-4">
-            <h3 className="font-sans text-lg text-foreground">
-              {site.name}
-            </h3>
-            <p className="text-muted flex-wrap text-sm">
-              {mission.heroShort}
-            </p>
+            <h3 className="text-foreground font-sans text-lg">{site.name}</h3>
+            <p className="text-muted flex-wrap text-sm">{mission.heroShort}</p>
             {isLoadingCollaborators ? (
               <div className="text-muted text-sm">Loading...</div>
             ) : (
@@ -38,7 +34,7 @@ export function Footer() {
                 {collaboratorsData?.hosts &&
                   collaboratorsData.hosts.length > 0 && (
                     <div>
-                      <h4 className="mb-2 text-sm font-semibold text-foreground">
+                      <h4 className="text-foreground mb-2 text-sm font-semibold">
                         Hosted by {attribution.lab}
                       </h4>
                       <div className="space-y-1">
@@ -49,7 +45,7 @@ export function Footer() {
                                 href={host.url}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="text-muted transition-colors hover:text-accent hover:underline"
+                                className="text-muted hover:text-accent transition-colors hover:underline"
                               >
                                 {host.name}
                               </Link>
@@ -64,61 +60,35 @@ export function Footer() {
               </>
             )}
           </div>
-          <div className="col-span-1 space-y-4">
-            <h4 className="text-sm font-semibold text-foreground">
-              Quick Links
-            </h4>
+          <div className="col-span-2 space-y-4">
+            <h4 className="text-foreground text-sm font-semibold">Resources</h4>
             <div className="flex flex-col space-y-2">
               <Link
-                href="/browse/molecules"
-                className="text-muted text-sm transition-colors hover:text-accent hover:underline"
-              >
-                Browse molecules
-              </Link>
-              <Link
-                href="/browse/nexafs"
-                className="text-muted text-sm transition-colors hover:text-accent hover:underline"
-              >
-                Browse NEXAFS
-              </Link>
-              <Link
-                href="/contribute"
-                className="text-muted text-sm transition-colors hover:text-accent hover:underline"
-              >
-                Contribute
-              </Link>
-              <Link
                 href="/wiki/home"
-                className="text-muted text-sm transition-colors hover:text-accent hover:underline"
+                className="text-muted hover:text-accent text-sm transition-colors hover:underline"
               >
-                NEXAFS wiki
+                Wiki
               </Link>
               <Link
                 href="/wiki/api"
-                className="text-muted text-sm transition-colors hover:text-accent hover:underline"
+                className="text-muted hover:text-accent text-sm transition-colors hover:underline"
               >
-                API reference
-              </Link>
-              <Link
-                href="/about"
-                className="text-muted text-sm transition-colors hover:text-accent hover:underline"
-              >
-                About
+                API
               </Link>
               <Link
                 href="mailto:brian.collins@wsu.edu"
-                className="text-muted text-sm transition-colors hover:text-accent hover:underline"
+                className="text-muted hover:text-accent text-sm transition-colors hover:underline"
               >
                 Contact
               </Link>
             </div>
           </div>
-          <div className="col-span-4 space-y-4">
-            <h4 className="text-sm font-semibold text-foreground">
+          <div className="col-span-3 space-y-4">
+            <h4 className="text-foreground text-sm font-semibold">
               Collaborators
             </h4>
             {isLoadingCollaborators ? (
-              <div className="text-sm text-foreground-500">Loading...</div>
+              <div className="text-foreground-500 text-sm">Loading...</div>
             ) : (
               <>
                 {collaboratorsData?.collaborators &&
@@ -131,7 +101,7 @@ export function Footer() {
                             href={collab.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-muted transition-colors hover:text-accent hover:underline"
+                            className="text-muted hover:text-accent transition-colors hover:underline"
                           >
                             {collab.name}
                           </Link>
@@ -157,7 +127,7 @@ export function Footer() {
           <div className="mt-4 flex justify-center gap-4 text-sm md:mt-0 md:justify-end">
             <Link
               href="/privacy"
-              className="text-muted text-sm transition-colors hover:text-accent hover:underline"
+              className="text-muted hover:text-accent text-sm transition-colors hover:underline"
             >
               Privacy
             </Link>
@@ -165,7 +135,7 @@ export function Footer() {
               href="https://github.com/WSU-Carbon-Lab/xray-atlas"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-muted text-sm transition-colors hover:text-accent hover:underline"
+              className="text-muted hover:text-accent text-sm transition-colors hover:underline"
             >
               GitHub
             </Link>
@@ -173,7 +143,7 @@ export function Footer() {
               href="https://wsu.edu/"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-muted text-sm transition-colors hover:text-accent hover:underline"
+              className="text-muted hover:text-accent text-sm transition-colors hover:underline"
             >
               WSU
             </Link>

--- a/src/lib/wiki-doc-nav.ts
+++ b/src/lib/wiki-doc-nav.ts
@@ -33,9 +33,15 @@ export const wikiDocTopics: readonly WikiDocTopic[] = [
     breadcrumbLabel: "Wiki home",
     overviewNavIcon: "wiki-home",
     sections: [
-      { id: "terminology-heading", label: "The zoo of names for the same idea" },
+      {
+        id: "terminology-heading",
+        label: "The zoo of names for the same idea",
+      },
       { id: "nexafs-probes", label: "What NEXAFS probes" },
-      { id: "representations-stored", label: "Representations stored in X-ray Atlas" },
+      {
+        id: "representations-stored",
+        label: "Representations stored in X-ray Atlas",
+      },
       { id: "coordinates-and-units", label: "Coordinates and units" },
     ],
   },
@@ -48,7 +54,10 @@ export const wikiDocTopics: readonly WikiDocTopic[] = [
       { id: "molecule-and-sample-layer", label: "Molecule and sample layer" },
       { id: "experiment-metadata-layer", label: "Experiment metadata layer" },
       { id: "spectrum-trace-layer", label: "Spectrum trace layer" },
-      { id: "provenance-and-attribution-layer", label: "Provenance and attribution layer" },
+      {
+        id: "provenance-and-attribution-layer",
+        label: "Provenance and attribution layer",
+      },
     ],
   },
   {
@@ -100,13 +109,107 @@ export const wikiDocTopics: readonly WikiDocTopic[] = [
  * @param pathname - Next.js pathname such as `/wiki/home` (no query or hash).
  * @returns The matching topic, or `undefined` when `pathname` is not a configured wiki entry.
  */
-export function wikiDocTopicForPathname(pathname: string): WikiDocTopic | undefined {
+export function wikiDocTopicForPathname(
+  pathname: string,
+): WikiDocTopic | undefined {
   const exact = wikiDocTopics.find((topic) => topic.href === pathname);
   if (exact) {
     return exact;
   }
   const prefixMatches = wikiDocTopics.filter(
-    (topic) => pathname.startsWith(`${topic.href}/`) || pathname.startsWith(topic.href),
+    (topic) =>
+      pathname.startsWith(`${topic.href}/`) || pathname.startsWith(topic.href),
   );
   return prefixMatches.sort((a, b) => b.href.length - a.href.length)[0];
+}
+
+/**
+ * Linear, reading-order entry that powers `Previous` / `Next` page controls.
+ *
+ * Each entry corresponds to a distinct rendered URL under `/wiki/*`. Sub-pages declared
+ * via section `href`s are inlined immediately after their parent topic.
+ */
+export interface WikiDocPage {
+  readonly href: string;
+  readonly label: string;
+}
+
+function buildWikiDocPages(): readonly WikiDocPage[] {
+  const pages: WikiDocPage[] = [];
+  const seen = new Set<string>();
+  const push = (href: string, label: string): void => {
+    if (seen.has(href)) {
+      return;
+    }
+    seen.add(href);
+    pages.push({ href, label });
+  };
+
+  for (const topic of wikiDocTopics) {
+    push(topic.href, topic.breadcrumbLabel);
+    for (const section of topic.sections) {
+      if (section.href && section.href !== topic.href) {
+        push(section.href, section.label);
+      }
+    }
+  }
+  return pages;
+}
+
+/**
+ * Reading-order list of wiki pages used to drive prev/next navigation controls.
+ *
+ * Order follows {@link wikiDocTopics} top-to-bottom, with each topic's section-level
+ * sub-pages (entries that declare their own `href`) inlined immediately after the topic.
+ */
+export const wikiDocPages: readonly WikiDocPage[] = buildWikiDocPages();
+
+/**
+ * Locates the wiki page entry whose `href` exactly matches `pathname`.
+ *
+ * Trailing slashes on `pathname` are tolerated; query strings and hashes must already be
+ * stripped by the caller.
+ *
+ * @param pathname - Next.js pathname such as `/wiki/api/v1`.
+ * @returns The matching page entry, or `undefined` when `pathname` is not a wiki page.
+ */
+export function wikiDocPageForPathname(
+  pathname: string,
+): WikiDocPage | undefined {
+  const normalized =
+    pathname.length > 1 && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
+  return wikiDocPages.find((page) => page.href === normalized);
+}
+
+/**
+ * Reading-order neighbors for a given wiki pathname.
+ *
+ * `current` is the matched page entry, and `previous` / `next` are the adjacent entries
+ * in {@link wikiDocPages}. The first page has no `previous`; the last page has no `next`.
+ * When `pathname` is outside the wiki page list, all three fields are `undefined` so
+ * callers can render disabled controls without throwing.
+ *
+ * @param pathname - Next.js pathname such as `/wiki/home` (no query or hash).
+ * @returns `{ current, previous, next }` neighbor entries.
+ */
+export function wikiDocPageNeighbors(pathname: string): {
+  readonly current: WikiDocPage | undefined;
+  readonly previous: WikiDocPage | undefined;
+  readonly next: WikiDocPage | undefined;
+} {
+  const current = wikiDocPageForPathname(pathname);
+  if (!current) {
+    return { current: undefined, previous: undefined, next: undefined };
+  }
+  const index = wikiDocPages.indexOf(current);
+  return {
+    current,
+    previous: index > 0 ? wikiDocPages[index - 1] : undefined,
+    next:
+      index >= 0 && index < wikiDocPages.length - 1
+        ? wikiDocPages[index + 1]
+        : undefined,
+  };
 }

--- a/src/lib/wiki-doc-nav.ts
+++ b/src/lib/wiki-doc-nav.ts
@@ -184,6 +184,55 @@ export function wikiDocPageForPathname(
 }
 
 /**
+ * Breadcrumb trail entry for a wiki pathname.
+ *
+ * Each entry represents one breadcrumb after the static `Home > Wiki` prefix. Entries
+ * with an `href` should render as links; entries without `href` are the terminal current
+ * page and should render as inert text.
+ */
+export interface WikiBreadcrumbItem {
+  readonly label: string;
+  readonly href?: string;
+}
+
+/**
+ * Resolves the breadcrumb trail beneath the static `Home > Wiki` prefix for a given
+ * wiki pathname.
+ *
+ * For top-level topic pages the trail is a single inert entry naming the topic. For
+ * sub-pages declared via section `href`s that differ from the topic `href`, the trail
+ * begins with a link to the parent topic and ends with an inert entry for the active
+ * sub-page (for example `/wiki/api/v1` returns
+ * `[{ label: "API", href: "/wiki/api" }, { label: "v1" }]`). When `pathname` is outside
+ * the wiki tree the trail is empty so the caller can render a default `Wiki` placeholder.
+ *
+ * @param pathname - Next.js pathname such as `/wiki/api/v1` (no query or hash).
+ * @returns Ordered breadcrumb entries beneath `Home > Wiki`.
+ */
+export function wikiDocBreadcrumbTrail(
+  pathname: string,
+): readonly WikiBreadcrumbItem[] {
+  const topic = wikiDocTopicForPathname(pathname);
+  if (!topic) {
+    return [];
+  }
+
+  const subPage = topic.sections.find(
+    (section) =>
+      section.href && section.href !== topic.href && section.href === pathname,
+  );
+
+  if (!subPage) {
+    return [{ label: topic.breadcrumbLabel }];
+  }
+
+  return [
+    { label: topic.breadcrumbLabel, href: topic.href },
+    { label: subPage.label },
+  ];
+}
+
+/**
  * Reading-order neighbors for a given wiki pathname.
  *
  * `current` is the matched page entry, and `previous` / `next` are the adjacent entries


### PR DESCRIPTION
## Summary

Adds inline page navigation controls (Copy Page, Previous, Next) to every `/wiki/*` route, deepens the wiki breadcrumb trail to surface API sub-pages, makes the v1 API reference accordion read as expandable, and trims the footer Resources column down to a minimal set of unique destinations.

## Changes

- New `WikiDocPageNav` client component (`src/components/about/wiki-doc-page-nav.tsx`) renders Copy Page + Previous/Next at the top of every wiki page, mounted into the existing breadcrumb row of `WikiDocShell`. Copy targets the rendered article inside `[data-wiki-main]` and writes both `text/html` (`outerHTML`) and `text/plain` (`innerText`) via `navigator.clipboard.write` + `ClipboardItem`, with `clipboard.writeText` and a hidden-textarea `document.execCommand("copy")` fallback for non-secure contexts.
- Reading-order page list and neighbor helper added to `src/lib/wiki-doc-nav.ts` (`wikiDocPages`, `wikiDocPageForPathname`, `wikiDocPageNeighbors`). Order: Wiki home → Data representation → Platform features → Contributions → API → OpenAPI → v1. Home omits Previous; final page omits Next.
- Breadcrumb trail helper (`wikiDocBreadcrumbTrail`) replaces the single trailing item in `WikiDocShell`, so `/wiki/api/openapi` and `/wiki/api/v1` render `Home > Wiki > API > OpenAPI` / `Home > Wiki > API > v1` while `/wiki/api` stays a single terminal entry (the topic page itself does not duplicate as a sub-page).
- v1 API reference (`src/components/about/api-v1-reference.tsx`) accordion triggers now render with a `ChevronDownIcon` indicator, hover state, and a "N routes" pill so they read as expandable controls; route groups are driven from a small `routeGroups` array.
- Footer Resources column (`src/components/layout/footer.tsx`) trimmed from seven entries to three (`Wiki`, `API`, `Contact`); column widened from `col-span-1` to `col-span-2` so labels render on a single line, with the Collaborators column rebalanced from `col-span-4` to `col-span-3`.

## Test Plan

- [x] Tested locally
- [ ] Tested OAuth flow (if auth changes)
- [x] Tested on mobile (if UI changes)

Verification:

- `bun run typecheck` clean.
- `bun run lint` clean for touched files (only pre-existing repo warnings remain).
- `bunx prettier --check` clean for all touched files.
- HTTP smoke check against the running dev server confirmed the expected presence/absence of `Copy Page`, `Previous page`, and `Next page` controls and the `data-wiki-main` copy target on `/wiki/home`, `/wiki/data-representation`, and `/wiki/api/v1`.
- Direct invocation of `wikiDocBreadcrumbTrail` confirmed `/wiki/api` returns a single terminal entry while `/wiki/api/openapi` and `/wiki/api/v1` chain through API.

## AI Role (required)

- [ ] Level 1: Mostly suggestions, tab completion, and minimal code generation
- [x] Level 2: Extensive code generation, but heavily managed; business and scientific logic was dictated by the contributor
- [ ] Level 3: Fully vibe coded; PRs using this level will likely be thrown away, but may contain nuggets a maintainer chooses to review

Validation: navigation order, breadcrumb structure, footer column composition, and disabled-state semantics were prescribed by the contributor and verified through `bun run typecheck`, `bun run lint`, `prettier --check`, dev-server HTTP smoke checks for the rendered controls, and a direct Bun-driven probe of `wikiDocBreadcrumbTrail` for the API route family.

## Screenshots (if UI changes)

Before | After
--- | ---
img | img