### PR TITLE
fix(auth): ORCID OIDC issuer for id_token validation

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -23,6 +23,7 @@ import {
 import { PrismaAdapterOrcid } from "~/server/auth/prisma-adapter-orcid";
 import { parseOrcidForStorage } from "~/lib/orcid";
 import { emitAuditEvent } from "~/server/audit";
+import { orcidOidcBaseUrl } from "~/server/auth/orcid-oidc-config";
 import { enrichUserProfileFromOrcidUserinfo } from "~/server/auth/orcid-userinfo";
 import { resolveWebAuthnRelayingParty } from "~/server/auth/webauthn-relaying-party";
 
@@ -37,12 +38,6 @@ interface ORCIDProfile {
   name?: string;
   given_name?: string;
   family_name?: string;
-}
-
-function orcidOAuthBaseUrl(): string {
-  return env.ORCID_USE_SANDBOX === "true"
-    ? "https://sandbox.orcid.org"
-    : "https://orcid.org";
 }
 
 function resolveGitHubCredentials(): {
@@ -66,13 +61,14 @@ function resolveGitHubCredentials(): {
 function ORCID(
   options: OAuthUserConfig<ORCIDProfile>,
 ): OAuthConfig<ORCIDProfile> {
-  const baseUrl = orcidOAuthBaseUrl();
+  const baseUrl = orcidOidcBaseUrl();
 
   return {
     ...options,
     id: "orcid",
     name: "ORCID",
     type: "oauth",
+    issuer: baseUrl,
     checks: ["pkce", "state"],
     authorization: {
       url: `${baseUrl}/oauth/authorize`,


### PR DESCRIPTION
## Summary

- Sets the ORCID provider `issuer` to `orcidOidcBaseUrl()` (`https://orcid.org` or sandbox) so Auth.js validates `id_token` `iss` against ORCID, not the default `https://authjs.dev`.
- Fixes production ORCID sign-in `CallbackRouteError` / issuer mismatch after compliance passkey work merged in #83.
- Single commit on this branch vs `main` (`1779ccd`); prior compliance/ORCID/tombstone changes are already on `main` via #83.

## Test plan

- [x] Sign in with ORCID on a deployment where `AUTH_URL` and ORCID app redirect URIs match production (or staging).
- [x] Confirm callback completes without `CallbackRouteError` / `iss` mismatch in logs.
- [x] Smoke-test existing session and passkey-gated contribute/admin flows still work after sign-in.