### PR TITLE
fix: harden blog integration after PR #90 production 500s

### DIFF
--- a/content/blog/2026-06-11-blog-launch.mdx
+++ b/content/blog/2026-06-11-blog-launch.mdx
@@ -7,11 +7,11 @@ tags: [release]
 category: releases
 ---
 
-We are excited to announe the launch of the X-ray Atlas blog. This will be the primary place for announcements of new features, bug fixes, other updates to the platform, and an insigth into the development philosophy and process.
+We are excited to announce the launch of the X-ray Atlas blog. This will be the primary place for announcements of new features, bug fixes, other updates to the platform, and an insight into the development philosophy and process.
 
 # The Blog Platform and our Stakeholders
 
-I am comfortable saying that the stakeholders for this platform have spread beyond what we initially envisioned. We now have interested parties from various synchrotron facilities, beamline scientists, industry researchers, academic institutions, and more; each with their own level of interest and involvement in the platform. Because of this, we need to imporve our ability to communicate with these stakeholders at the level each group wants to engage at.
+I am comfortable saying that the stakeholders for this platform have spread beyond what we initially envisioned. We now have interested parties from various synchrotron facilities, beamline scientists, industry researchers, academic institutions, and more; each with their own level of interest and involvement in the platform. Because of this, we need to improve our ability to communicate with these stakeholders at the level each group wants to engage at.
 
 ## RSS Feed Subscription
 

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,9 @@ import "./src/env.js";
 /** @type {import("next").NextConfig} */
 const config = {
   serverExternalPackages: ["pg", "@prisma/adapter-pg"],
+  outputFileTracingIncludes: {
+    "/*": ["./content/blog/**/*"],
+  },
   async redirects() {
     return [
       {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -83,7 +83,7 @@ const blogMdxComponents: MDXComponents = {
     <h2
       {...props}
       className={cn(
-        "text-foreground mt-10 scroll-mt-24 text-2xl font-semibold tracking-tight",
+        "font-display text-foreground mt-10 scroll-mt-24 text-2xl font-semibold tracking-tight",
         className,
       )}
     >
@@ -94,7 +94,7 @@ const blogMdxComponents: MDXComponents = {
     <h3
       {...props}
       className={cn(
-        "text-foreground mt-8 scroll-mt-24 text-xl font-semibold tracking-tight",
+        "font-display text-foreground mt-8 scroll-mt-24 text-xl font-semibold tracking-tight",
         className,
       )}
     >

--- a/src/components/blog/blog-category-hero.tsx
+++ b/src/components/blog/blog-category-hero.tsx
@@ -9,7 +9,7 @@ import {
   type BlogCategorySlug,
 } from "~/lib/content/blog-categories";
 import type { BlogEntry } from "~/lib/content/blog-loader";
-import { formatBlogDate } from "~/lib/content/blog-presentation";
+import { formatBlogDate } from "~/lib/content/blog-date-format";
 
 const BLOG_STANDING_DESCRIPTION =
   "Announcements and engineering notes from the X-ray Atlas team.";

--- a/src/components/home/whats-new-hero-badge.tsx
+++ b/src/components/home/whats-new-hero-badge.tsx
@@ -4,7 +4,7 @@ import type { ReactElement } from "react";
 import Link from "next/link";
 import { ArrowRightIcon, NewspaperIcon } from "@heroicons/react/24/outline";
 import { cn } from "@heroui/styles";
-import { formatBlogDate } from "~/lib/content/blog-presentation";
+import { formatBlogDate } from "~/lib/content/blog-date-format";
 import type { WhatsNewSummary } from "~/lib/whats-new-summary";
 import { useWhatsNewSeen } from "~/lib/whats-new-seen";
 

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -21,7 +21,7 @@ import { ORCIDIcon } from "~/components/icons";
 import { Avatar, Badge, Button } from "@heroui/react";
 import { cn } from "@heroui/styles";
 import type { ResearcherAttributionBadgeStatus } from "~/lib/nexafs-attribution";
-import { formatBlogDate } from "~/lib/content/blog-presentation";
+import { formatBlogDate } from "~/lib/content/blog-date-format";
 import type { WhatsNewSummary } from "~/lib/whats-new-summary";
 import { useWhatsNewSeen } from "~/lib/whats-new-seen";
 import { ContributorHoverCard } from "~/components/attribution/contributor-hover-card";

--- a/src/lib/content/blog-date-format.ts
+++ b/src/lib/content/blog-date-format.ts
@@ -1,0 +1,43 @@
+/**
+ * Client-safe blog date formatting without MDX/remark dependencies.
+ *
+ * Keeps calendar-day display helpers out of `blog-presentation.ts` so Header and
+ * account menu client components do not import unified/remark at module init.
+ */
+
+/**
+ * Formats a blog calendar day (`YYYY-MM-DD`) for display.
+ *
+ * When `relative` is true and the post is within the last 14 days, returns compact
+ * relative labels (`Today`, `Yesterday`, `N days ago`). Otherwise returns a long-form
+ * US locale date. On statically generated blog routes, relative strings reflect the
+ * build timestamp until the next deployment.
+ */
+export function formatBlogDate(
+  isoDate: string,
+  options?: { relative?: boolean; now?: Date },
+): string {
+  const date = new Date(`${isoDate}T12:00:00.000Z`);
+  const now = options?.now ?? new Date();
+
+  if (options?.relative) {
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    if (diffDays >= 0 && diffDays <= 14) {
+      if (diffDays === 0) {
+        return "Today";
+      }
+      if (diffDays === 1) {
+        return "Yesterday";
+      }
+      return `${diffDays} days ago`;
+    }
+  }
+
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/src/lib/content/blog-loader.ts
+++ b/src/lib/content/blog-loader.ts
@@ -3,7 +3,7 @@ import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import matter from "gray-matter";
 import type { BlogCategorySlug } from "~/lib/content/blog-categories";
-import { blogSlugHash } from "~/lib/content/blog-presentation";
+import { blogSlugHash } from "~/lib/content/blog-slug-hash";
 import {
   blogFrontmatterSchema,
   type BlogFrontmatter,

--- a/src/lib/content/blog-presentation.ts
+++ b/src/lib/content/blog-presentation.ts
@@ -5,28 +5,9 @@ import remarkParse from "remark-parse";
 import { unified } from "unified";
 import { visit } from "unist-util-visit";
 import { formatBlogDate } from "~/lib/content/blog-date-format";
+import { blogSlugHash } from "~/lib/content/blog-slug-hash";
 
-export { formatBlogDate };
-
-/** Public URL prefix for blog post images; kept inline so client components can import date helpers. */
-const BLOG_ASSETS_URL_PREFIX = "/blog/blog-assets";
-
-function hashSlug(slug: string): number {
-  let hash = 0;
-  for (let index = 0; index < slug.length; index += 1) {
-    hash = (hash * 31 + slug.charCodeAt(index)) >>> 0;
-  }
-  return hash;
-}
-
-/**
- * Returns a deterministic opaque hash for a blog slug used in teaser tiles without
- * exposing the slug in the DOM.
- */
-export function blogSlugHash(slug: string): string {
-  const hash = hashSlug(slug);
-  return hash.toString(16).padStart(8, "0");
-}
+export { formatBlogDate, blogSlugHash };
 
 /** One in-page heading extracted from blog MDX for table-of-contents links. */
 export interface BlogHeading {
@@ -82,6 +63,9 @@ export function extractHeadings(body: string): BlogHeading[] {
 
   return headings;
 }
+
+/** Public URL prefix for blog post images served from `content/blog/blog-assets`. */
+const BLOG_ASSETS_URL_PREFIX = "/blog/blog-assets";
 
 /**
  * Maps blog frontmatter `heroImage` values to public URLs under `/blog/blog-assets`.

--- a/src/lib/content/blog-presentation.ts
+++ b/src/lib/content/blog-presentation.ts
@@ -4,6 +4,9 @@ import type { Heading } from "mdast";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
 import { visit } from "unist-util-visit";
+import { formatBlogDate } from "~/lib/content/blog-date-format";
+
+export { formatBlogDate };
 
 /** Public URL prefix for blog post images; kept inline so client components can import date helpers. */
 const BLOG_ASSETS_URL_PREFIX = "/blog/blog-assets";
@@ -51,43 +54,6 @@ export function readingTimeMinutes(body: string): number {
   text = text.replace(/[#>*_~|-]/g, " ");
   const words = text.trim().split(/\s+/).filter(Boolean).length;
   return Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
-}
-
-/**
- * Formats a blog calendar day (`YYYY-MM-DD`) for display.
- *
- * When `relative` is true and the post is within the last 14 days, returns compact
- * relative labels (`Today`, `Yesterday`, `N days ago`). Otherwise returns a long-form
- * US locale date. On statically generated blog routes, relative strings reflect the
- * build timestamp until the next deployment.
- */
-export function formatBlogDate(
-  isoDate: string,
-  options?: { relative?: boolean; now?: Date },
-): string {
-  const date = new Date(`${isoDate}T12:00:00.000Z`);
-  const now = options?.now ?? new Date();
-
-  if (options?.relative) {
-    const diffMs = now.getTime() - date.getTime();
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-    if (diffDays >= 0 && diffDays <= 14) {
-      if (diffDays === 0) {
-        return "Today";
-      }
-      if (diffDays === 1) {
-        return "Yesterday";
-      }
-      return `${diffDays} days ago`;
-    }
-  }
-
-  return date.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    timeZone: "UTC",
-  });
 }
 
 /**

--- a/src/lib/content/blog-slug-hash.ts
+++ b/src/lib/content/blog-slug-hash.ts
@@ -1,0 +1,16 @@
+function hashSlug(slug: string): number {
+  let hash = 0;
+  for (let index = 0; index < slug.length; index += 1) {
+    hash = (hash * 31 + slug.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+}
+
+/**
+ * Returns a deterministic opaque hash for a blog slug used in teaser tiles without
+ * exposing the slug in the DOM.
+ */
+export function blogSlugHash(slug: string): string {
+  const hash = hashSlug(slug);
+  return hash.toString(16).padStart(8, "0");
+}

--- a/src/lib/whats-new-summary.ts
+++ b/src/lib/whats-new-summary.ts
@@ -16,24 +16,29 @@ export interface WhatsNewSummary {
  * or the newest published post when no release-category post exists.
  */
 export async function getWhatsNewSummary(): Promise<WhatsNewSummary | null> {
-  const releasePost = await getLatestReleasePost();
-  if (releasePost) {
-    return {
-      slug: releasePost.slug,
-      title: releasePost.frontmatter.title,
-      date: releasePost.frontmatter.date,
-    };
-  }
+  try {
+    const releasePost = await getLatestReleasePost();
+    if (releasePost) {
+      return {
+        slug: releasePost.slug,
+        title: releasePost.frontmatter.title,
+        date: releasePost.frontmatter.date,
+      };
+    }
 
-  const entries = await getBlogEntries();
-  const latestPost = entries.find(isListableBlogEntry);
-  if (!latestPost) {
+    const entries = await getBlogEntries();
+    const latestPost = entries.find(isListableBlogEntry);
+    if (!latestPost) {
+      return null;
+    }
+
+    return {
+      slug: latestPost.slug,
+      title: latestPost.frontmatter.title,
+      date: latestPost.frontmatter.date,
+    };
+  } catch (error) {
+    console.error("[getWhatsNewSummary] Failed to load blog highlight", error);
     return null;
   }
-
-  return {
-    slug: latestPost.slug,
-    title: latestPost.frontmatter.title,
-    date: latestPost.frontmatter.date,
-  };
 }


### PR DESCRIPTION
## Summary

After merging PR #90 (blog, RSS, What's New), production returned **500** on `/about` and on the home page when the client batched tRPC (including What's New).

**Root cause (combined):**
- Blog MDX / content loading pulled into layout or server paths that broke when `content/blog` was missing or mis-resolved in the deployment trace.
- Client-side code imported **remark/unified** transitively via `blog-presentation`, bloating or breaking the client bundle and server/client boundary.
- Missing or incomplete wiring for the `content/blog` tree in the production build artifact.

**Fixes applied:**
- Harden blog loading and presentation so server layouts and What's New do not depend on fragile MDX/remark paths in client imports.
- Align blog typography: **h2/h3** use the same serif stack as the rest of the site.
- Copy and typo fixes in blog-related surfaces.

**Verification:** `bun run typecheck`, `bun run lint`, and production `build` pass locally.

## Test plan

- [ ] Deploy preview or production-like build; confirm `/` loads without 500 and home What's New / hero updates render.
- [ ] Confirm `/about` loads without 500.
- [ ] Open a published blog post; check h2/h3 serif headings and no layout regressions.
- [ ] Confirm `/blog` index and RSS routes still respond.
- [ ] Smoke-check account dropdown What's New unread state if applicable.